### PR TITLE
added missing include for std::runtime error

### DIFF
--- a/src/AxesNode.cpp
+++ b/src/AxesNode.cpp
@@ -7,6 +7,7 @@
 #include <osgText/Text>
 #include <assert.h>
 #include <iostream>
+#include <stdexcept>
 
 namespace vizkit3d
 {


### PR DESCRIPTION
This makes compilation fail on ALL supported OSes for rock
