### PR TITLE
Missing header causes build failure

### DIFF
--- a/src/AxesNode.cpp
+++ b/src/AxesNode.cpp
@@ -7,6 +7,7 @@
 #include <osgText/Text>
 #include <assert.h>
 #include <iostream>
+#include <stdexcept>
 
 namespace vizkit3d
 {


### PR DESCRIPTION
got the following build error:

```
'make --jobserver-fds=5,6 -j' returned status 2
    see /media/data/Projects/BesMan/Software/RockDev/install/log/gui/vizkit3d-build.log for details
    last 10 lines are:

    /media/data/Projects/BesMan/Software/RockDev/gui/vizkit3d/src/AxesNode.cpp:155:19: error: 'runtime_error' is not a member of 'std'
    At global scope:
    cc1plus: warning: unrecognized command line option "-Wno-unused-local-typedefs" [enabled by default]
    ICECC[28806] 10:42:53: Compiled on 10.250.7.14
    make[2]: *** [src/CMakeFiles/vizkit3d.dir/AxesNode.cpp.o] Error 1
    make[2]: *** Waiting for unfinished jobs....
    /media/data/Projects/BesMan/Software/RockDev/gui/vizkit3d/src/qtpropertybrowser/qtpropertymanager.h:1335:26: warning: 'QtCursorDatabase* cursorDatabase()' defined but not used [-Wunused-function]
    cc1plus: warning: unrecognized command line option "-Wno-unused-local-typedefs" [enabled by default]
    make[1]: *** [src/CMakeFiles/vizkit3d.dir/all] Error 2
    make: *** [all] Error 2
```

Including the header makes `std::runtime_error` available.
