### PR TITLE
fix wrong transformer graph generated in some configurations

### DIFF
--- a/src/TransformerGraph.cpp
+++ b/src/TransformerGraph.cpp
@@ -353,16 +353,30 @@ bool TransformerGraph::getTransformation(osg::Node &transformer,const std::strin
     return true;
 }
 
-bool TransformerGraph::setTransformation(osg::Node &transformer,const std::string &source_frame,const std::string &target_frame,
+static void invertOSGTransform(osg::Vec3d& trans, osg::Quat& quat,
+        osg::PositionAttitudeTransform*& source, osg::PositionAttitudeTransform*& target,
+        std::string& source_frame, std::string& target_frame)
+{
+    quat = quat.inverse();
+    trans = -(quat * trans);
+    std::swap(source, target);
+    std::swap(source_frame, target_frame);
+}
+
+bool TransformerGraph::setTransformation(osg::Node &transformer,const std::string &_source_frame,const std::string &_target_frame,
         const osg::Quat &_quat, const osg::Vec3d &_trans)
 {
+    std::string source_frame = _source_frame;
+    std::string target_frame = _target_frame;
     osg::PositionAttitudeTransform *source = FindFrame::find(transformer,source_frame);
     osg::PositionAttitudeTransform *target = FindFrame::find(transformer,target_frame);
     osg::Quat quat = _quat;
     osg::Vec3d trans = _trans;
 
     if(!source)
+    {
         source = getTransform(addFrame(transformer,source_frame));
+    }
     if(!target)
         target = getTransform(addFrame(transformer,target_frame));
 
@@ -371,21 +385,19 @@ bool TransformerGraph::setTransformation(osg::Node &transformer,const std::strin
         std::cerr << "cannot set transformation between " << source_frame << " and " << target_frame << ". They are identically" << std::endl;
         return false;
     }
-
-    //someone tries to move the world which is not possible
-    //invert transformation
-    if(target == &transformer)
+    
+    if (source->getParent(0) == target)
     {
-        quat = quat.inverse();
-        trans = -trans;
-        osg::PositionAttitudeTransform *t = target;
-        target = source;
-        source = t;
+        invertOSGTransform(trans, quat, source, target, source_frame, target_frame);
     }
-
-    // if it is not the case attach target to the source node
-    if(target->getParent(0) != source)
+    else if (target->getParent(0) != source)
     {
+        if (target == &transformer || (source->getParent(0) == &transformer && target->getParent(0) != &transformer))
+        {
+            invertOSGTransform(trans, quat, source, target, source_frame, target_frame);
+        }
+
+
 	osg::ref_ptr<osg::Node> node = target; //insures that node is not deleted
         removeFrame(transformer,target_frame);
         source->addChild(node);

--- a/src/TransformerGraph.hpp
+++ b/src/TransformerGraph.hpp
@@ -85,6 +85,14 @@ namespace vizkit3d
          */
         static std::string getFrameName(osg::Node &transformer,osg::Node *node);
 
+        typedef std::pair<std::string, std::string> EdgeDescription;
+        typedef std::list<EdgeDescription> GraphDescription;
+
+        /** Returns the shape of the graph as a list of frame names pairs
+         * (from->to)
+         */
+        static GraphDescription getGraphDescription(osg::Node& transformer);
+
         /**
          * Sets the transformation between two subsequently coordinate frames.
          *

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,9 @@
 rock_find_qt4()
 
-rock_testsuite(testWidget testWidget.cpp
+rock_testsuite(testGUI suite.cpp testWidget.cpp
+    DEPS vizkit3d
+    LIBS ${Boost_THREAD_LIBRARY} ${Boost_SYSTEM_LIBRARY})
+
+rock_testsuite(testCore suite.cpp testTransformerGraph.cpp
     DEPS vizkit3d
     LIBS ${Boost_THREAD_LIBRARY} ${Boost_SYSTEM_LIBRARY})

--- a/test/suite.cpp
+++ b/test/suite.cpp
@@ -1,0 +1,5 @@
+// Do NOT add anything to this file
+// This header from boost takes ages to compile, so we make sure it is compiled
+// only once (here)
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>

--- a/test/testTransformerGraph.cpp
+++ b/test/testTransformerGraph.cpp
@@ -1,0 +1,77 @@
+#include <vizkit3d/TransformerGraph.hpp>
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+
+typedef osg::ref_ptr<osg::Node> NodePtr;
+using namespace vizkit3d;
+using namespace std;
+
+// Helper function, defined at the bottom
+static void __require_same_graph(char const** expected_graph, size_t expected_graph_size, NodePtr root_node);
+#define REQUIRE_SAME_GRAPH(expected_graph, root_node) \
+    __require_same_graph(expected_graph, sizeof(expected_graph) / sizeof(*expected_graph) / 2, root_node)
+
+BOOST_AUTO_TEST_SUITE(vizkit3d_TransformerGraph)
+
+static const osg::Quat Identity(0, 0, 0, 1);
+static const osg::Vec3d Zero(0, 0, 0);
+
+BOOST_AUTO_TEST_CASE(it_appends_new_edges_to_the_existing_graph)
+{
+    NodePtr root(TransformerGraph::create("root"));
+
+    TransformerGraph::setTransformation(*root, "frame1", "frame2", Identity, Zero);
+    TransformerGraph::setTransformation(*root, "frame3", "frame2", Identity, Zero);
+
+    char const* expected_graph[] = {
+        "root", "frame1",
+        "frame1", "frame2",
+        "frame2", "frame3"
+    };
+    REQUIRE_SAME_GRAPH(expected_graph, root);
+}
+
+BOOST_AUTO_TEST_CASE(it_keeps_existing_links_even_if_updates_are_provided_reversed)
+{
+    NodePtr root(TransformerGraph::create("root"));
+
+    TransformerGraph::setTransformation(*root, "frame1", "frame2", Identity, Zero);
+    TransformerGraph::setTransformation(*root, "frame2", "frame3", Identity, Zero);
+    TransformerGraph::setTransformation(*root, "frame3", "frame2", Identity, Zero);
+
+    char const* expected_graph[] = {
+        "root", "frame1",
+        "frame1", "frame2",
+        "frame2", "frame3"
+    };
+    REQUIRE_SAME_GRAPH(expected_graph, root);
+}
+
+BOOST_AUTO_TEST_SUITE_END();
+
+
+/** NOTE: Helper functions */
+static void __require_same_graph(char const** expected_graph, size_t expected_graph_size, NodePtr root_node)
+{
+    TransformerGraph::GraphDescription description = TransformerGraph::getGraphDescription(*root_node);
+    BOOST_TEST_MESSAGE("Checking equality on graph");
+    for (TransformerGraph::GraphDescription::const_iterator it = description.begin();
+            it != description.end(); ++it)
+    {
+        BOOST_TEST_MESSAGE("  " << it->first << " " << it->second);
+    }
+
+    BOOST_REQUIRE_EQUAL(description.size(), expected_graph_size);
+
+    for (size_t i = 0; i < expected_graph_size; ++i)
+    {
+        TransformerGraph::EdgeDescription edge =
+            make_pair<string>(expected_graph[i * 2], expected_graph[i * 2 + 1]);
+
+        TransformerGraph::GraphDescription::const_iterator it =
+            find(description.begin(), description.end(), edge);
+
+        BOOST_TEST_MESSAGE("expected edge " << edge.first << " -> " << edge.second);
+        BOOST_REQUIRE( it != description.end() );
+    }
+}

--- a/test/testWidget.cpp
+++ b/test/testWidget.cpp
@@ -1,11 +1,3 @@
-#ifndef BOOST_TEST_DYN_LINK
-    #define BOOST_TEST_DYN_LINK
-#endif
-
-#define BOOST_TEST_MAIN
-#define BOOST_TEST_MODULE "test"
-#define BOOST_AUTO_TEST_MAIN
-
 #include "../src/Vizkit3DWidget.hpp"
 #include "../src/QtThreadedWidget.hpp"
 #include <boost/test/unit_test.hpp>


### PR DESCRIPTION
The current code takes zero step to avoid splitting the transform
graph into separate trees. It leads to completely wrong
visualizations quite easily.

This tries very hard to avoid that situation, but still has some
corner cases (e.g. if a transform links the leafs of two transform
trees).