### PR TITLE
makes updateMainNode() and createMainNode() public for external use

### DIFF
--- a/src/Vizkit3DPlugin.hpp
+++ b/src/Vizkit3DPlugin.hpp
@@ -219,17 +219,19 @@ class VizPluginBase : public QObject
         */
         void clicked(float x, float y);
 
+    public:
+    	/** override this function to update the visualisation.
+    	 * @param node contains a point to the node which can be modified.
+    	 */
+    	virtual void updateMainNode(osg::Node* node) = 0;
+
+    	/** override this method to provide your own main node.
+    	 * @return node derived from osg::Group
+    	 */
+    	virtual osg::ref_ptr<osg::Node> createMainNode();
 
     protected:
-	/** override this function to update the visualisation.
-	 * @param node contains a point to the node which can be modified.
-	 */
-	virtual void updateMainNode(osg::Node* node) = 0;
 
-	/** override this method to provide your own main node.
-	 * @return node derived from osg::Group
-	 */ 
-	virtual osg::ref_ptr<osg::Node> createMainNode();
 
         /** override this method to provide your own QDockWidgets.
          * The QDockWidgets will automatically attached to the main window.


### PR DESCRIPTION
As you (might) know I started to merge the rock simulation ui with vizkit.

One requirement is that the simulation visualization has no (direct) Qt bindings.
My solution is to use plugins, where one of them is able to directly load vizkit3d plugins (keeping the visualization core independen of Qt). 

This also includes not using the Qt widget for creation and updates, requiring the methods to be public

The lib will be usable in two ways:

* For vizkit3d just the core as content window (vizkit infrastructure stays as it is (Plugin loading, ruby bindings), features from mars_graphics are added (shaders, etc), code (i.e. cameras, node picking) is shared between both)
* For mars with the possibility to load and update vizkit3d plugins 

I can meet and discuss with Alex, in case this is unclear.


