### PR TITLE
remove the ancient ruby adapter implementation

### DIFF
--- a/src/Vizkit3DPlugin.cpp
+++ b/src/Vizkit3DPlugin.cpp
@@ -181,11 +181,6 @@ void VizPluginBase::setDirty()
     dirty = true;
 }
 
-QObject* vizkit3d::VizPluginBase::getRubyAdapterCollection()
-{
-    return &adapterCollection;
-}
-
 bool VizPluginBase::isPluginEnabled()
 {
     return plugin_enabled;


### PR DESCRIPTION
This has been undocumented and deprecated for years now

It is marked as do-not-merge as I did not build the whole Rock setup with it, so it might break compilation
of some old vizkit3d plugins.
