### PR TITLE
Give access to changing manipulators from ruby

### DIFF
--- a/src/QPropertyBrowserWidget.cpp
+++ b/src/QPropertyBrowserWidget.cpp
@@ -88,10 +88,7 @@ void QPropertyBrowserWidget::addProperties(QObject* obj,QObject* parent)
             if(prop.type() == QVariant::StringList)
             {
                 QtVariantProperty* property = variantManager->addProperty(QtVariantPropertyManager::enumTypeId(),prop.name());
-                QStringList string_list = var.toStringList();
-                if(!string_list.empty())
-                    property->setValue(string_list.front());
-                property->setAttribute("enumNames",var);
+                property->setAttribute("enumNames", var);
                 properties.push_back(property);
             }
             else
@@ -220,17 +217,10 @@ void QPropertyBrowserWidget::propertyChangedInObject(QString property_name)
             if(!value.isValid())
                 return;
 
-            // emulate string list by using enum factory
-            if(value.type() == QVariant::StringList)
-            {
-                QtVariantProperty* prop = dynamic_cast<QtVariantProperty*>(property);
-                prop->setValue(value.toStringList().front());
-                prop->setAttribute("enumNames",value);
-            }
+            if (value.type() == QVariant::StringList)
+                dynamic_cast<QtVariantProperty*>(property)->setAttribute("enumNames", value);
             else
-            {
                 variantManager->setValue(property, value);
-            }
         }
     }
 }

--- a/src/Vizkit3DPlugin.cpp
+++ b/src/Vizkit3DPlugin.cpp
@@ -229,18 +229,23 @@ void VizPluginBase::deleteOldData()
     oldNodes->removeChild(0,oldNodes->getNumChildren());
 }
 
+Vizkit3DWidget* VizPluginBase::getWidget() const
+{
+    return dynamic_cast<Vizkit3DWidget*>(this->parent());
+}
+
 QStringList VizPluginBase::getVisualizationFrames() const
 {
-    Vizkit3DWidget *parent = dynamic_cast<Vizkit3DWidget*>(this->parent());
-    if(!parent)
+    if (!getWidget())
         return QStringList();
-    QStringList *list = parent->getVisualizationFrames();
-    if(!current_frame.isEmpty() && !list->isEmpty())
+
+    QStringList list = getWidget()->getVisualizationFrames();
+    if(!current_frame.isEmpty() && !list.isEmpty())
     {
-        list->removeOne(current_frame);
-        list->prepend(current_frame);
+        list.removeOne(current_frame);
+        list.prepend(current_frame);
     }
-    return QStringList(*list);
+    return list;
 }
 
 QString VizPluginBase::getVisualizationFrame() const
@@ -252,22 +257,18 @@ QString VizPluginBase::getVisualizationFrame() const
 // this is called from the property browser
 void VizPluginBase::setVisualizationFrame(const QStringList &frames)
 {
-    if(frames.isEmpty())
+    if (frames.empty())
         return;
-
-    Vizkit3DWidget *parent = dynamic_cast<Vizkit3DWidget*>(this->parent());
-    if(!parent)
-        return;
-    parent->setPluginDataFrameIntern(frames.front(),this);
-    current_frame = frames.front();
+    
+    setVisualizationFrame(frames.front());
 }
 
 void VizPluginBase::setVisualizationFrame(const QString &frame)
 {
-    Vizkit3DWidget *parent = dynamic_cast<Vizkit3DWidget*>(this->parent());
-    if(!parent)
+    if (!getWidget())
         return;
-    parent->setPluginDataFrameIntern(frame,this);
+
+    getWidget()->setPluginDataFrameIntern(frame,this);;
     current_frame = frame;
     emit propertyChanged("frame");
 }

--- a/src/Vizkit3DPlugin.hpp
+++ b/src/Vizkit3DPlugin.hpp
@@ -90,6 +90,7 @@ class VizPluginRubyAdapterCollection : public QObject
     protected:
         std::vector<VizPluginRubyAdapterBase*> adapterList;
 };
+class Vizkit3DWidget;
 
 /** 
  * Interface class for all visualization plugins based on vizkit3d. All plugins
@@ -119,6 +120,12 @@ class VizPluginBase : public QObject
     public:
         VizPluginBase(QObject *parent=NULL);
         ~VizPluginBase();
+
+        /** The underlying Vizkit3D Widget
+         *
+         * May be NULL if the plugin is e.g. built as a child of another plugin
+         */
+        Vizkit3DWidget* getWidget() const;
 
 	/** @return true if the plugins internal state has been updated */
 	virtual bool isDirty() const;
@@ -182,9 +189,22 @@ class VizPluginBase : public QObject
 
 	void setPose(const QVector3D &position, const QQuaternion &orientation);
 
+        /** Returns the list of available visualization frames
+         *
+         * It is used for the relevant Q_PROPERTY to get a combobox
+         */
         QStringList getVisualizationFrames() const;
+
+        /** Returns the frame at which this plugin is attached
+         */
         QString getVisualizationFrame() const;
+
+        /** @overload Helper method to set the visualization frame from the Qt Property Browser
+         */
         void setVisualizationFrame(const QStringList &frames);
+
+        /** Set the name of the frame which is the origin of this plugin
+         */
         void setVisualizationFrame(const QString &frame);
 
        /**

--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -32,7 +32,14 @@
 using namespace vizkit3d;
 using namespace std;
 
-Vizkit3DConfig::Vizkit3DConfig(QObject *parent):QObject(parent)
+Vizkit3DWidget* Vizkit3DConfig::getWidget() const
+{
+    Vizkit3DWidget *parent = dynamic_cast<Vizkit3DWidget*>(this->parent());
+    assert(parent);
+    return parent;
+}
+
+Vizkit3DConfig::Vizkit3DConfig(Vizkit3DWidget *parent):QObject(parent)
 {
     setObjectName("Viewer");
     connect(parent, SIGNAL(propertyChanged(QString)),this,SIGNAL(propertyChanged(QString)));
@@ -40,82 +47,53 @@ Vizkit3DConfig::Vizkit3DConfig(QObject *parent):QObject(parent)
 
 bool Vizkit3DConfig::isAxes() const
 {
-    Vizkit3DWidget *parent = dynamic_cast<Vizkit3DWidget*>(this->parent());
-    if(!parent)
-        return false;
-    return parent->isAxes();
+    return getWidget()->isAxes();
 }
 
 void Vizkit3DConfig::setAxes(bool value)
 {
-    Vizkit3DWidget *parent = dynamic_cast<Vizkit3DWidget*>(this->parent());
-    if(!parent)
-        return;
-    parent->setAxes(value);
+    return getWidget()->setAxes(value);
 }
 
 QStringList Vizkit3DConfig::getVisualizationFrames() const
 {
-    Vizkit3DWidget *parent = dynamic_cast<Vizkit3DWidget*>(this->parent());
-    if(!parent)
-        return QStringList();
-    return *parent->getVisualizationFrames();
+    return getWidget()->getVisualizationFrames();
 }
 
 void Vizkit3DConfig::setVisualizationFrame(const QStringList &frames)
 {
-    Vizkit3DWidget *parent = dynamic_cast<Vizkit3DWidget*>(this->parent());
-    if(!parent && frames.isEmpty())
-        return;
-    return parent->setVisualizationFrame(frames.front(),false);
+    return getWidget()->setVisualizationFrame(frames.front(),false);
 }
 
 bool Vizkit3DConfig::isTransformer() const
 {
-    Vizkit3DWidget *parent = dynamic_cast<Vizkit3DWidget*>(this->parent());
-    if(!parent)
-        return false;
-    return parent->isTransformer();
+    return getWidget()->isTransformer();
 }
 
 void Vizkit3DConfig::setTransformer(bool value)
 {
-    Vizkit3DWidget *parent = dynamic_cast<Vizkit3DWidget*>(this->parent());
-    if(!parent)
-        return;
-    parent->setTransformer(value);
+    return getWidget()->setTransformer(value);
 }
 
 QColor Vizkit3DConfig::getBackgroundColor() const
 {
-    Vizkit3DWidget *parent = dynamic_cast<Vizkit3DWidget*>(this->parent());
-    if(!parent)
-        return QColor();
-    return parent->getBackgroundColor();
+    return getWidget()->getBackgroundColor();
 }
 
 void Vizkit3DConfig::setBackgroundColor(QColor color)
 {
-    Vizkit3DWidget *parent = dynamic_cast<Vizkit3DWidget*>(this->parent());
-    if(!parent)
-        return;
-    return parent->setBackgroundColor(color);
+    return getWidget()->setBackgroundColor(color);
 }
 
 void Vizkit3DConfig::setAxesLabels(bool value)
 {
-    Vizkit3DWidget *parent = dynamic_cast<Vizkit3DWidget*>(this->parent());
-    if(!parent)
-        return;
-    parent->setAxesLabels(value);
+    return getWidget()->setAxesLabels(value);
 }
 
 bool Vizkit3DConfig::isAxesLabels() const
 {
-    Vizkit3DWidget *parent = dynamic_cast<Vizkit3DWidget*>(this->parent());
-    if(!parent)
-        return false;
-    return parent->isAxesLabels();
+    return getWidget()->isAxesLabels();
+}
 }
 
 Vizkit3DWidget::Vizkit3DWidget( QWidget* parent,const QString &world_name)

--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -970,6 +970,9 @@ void Vizkit3DWidget::setCameraManipulator(CAMERA_MANIPULATORS manipulatorType, b
         case FLIGHT_MANIPULATOR:
             newManipulator = new osgGA::FlightManipulator;
             break;
+        case ORBIT_MANIPULATOR:
+            newManipulator = new osgGA::FlightManipulator;
+            break;
         case TERRAIN_MANIPULATOR:
             newManipulator = new osgGA::TerrainManipulator;
             break;

--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -991,5 +991,6 @@ void Vizkit3DWidget::setCameraManipulator(CAMERA_MANIPULATORS manipulatorType, b
 
     setCameraManipulator(newManipulator);
     currentManipulator = manipulatorType;
+    emit propertyChanged("manipulator");
 }
 

--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -930,6 +930,11 @@ QObject* Vizkit3DWidget::loadPlugin(QString lib_name,QString plugin_name)
     return plugin;
 }
 
+QString Vizkit3DWidget::getCameraManipulatorName() const
+{
+    return Vizkit3DConfig::manipulatorIDToName(getCameraManipulator());
+}
+
 CAMERA_MANIPULATORS Vizkit3DWidget::getCameraManipulator() const
 {
     return currentManipulator;

--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -66,7 +66,8 @@ void Vizkit3DConfig::setAxes(bool value)
 QStringList Vizkit3DConfig::getVisualizationFrames() const
 {
     QStringList frames = getWidget()->getVisualizationFrames();
-    frames.push_front(getWidget()->getVisualizationFrame());
+    if (!frames.isEmpty())
+        frames.push_front(getWidget()->getVisualizationFrame());
     return frames;
 }
 

--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -132,14 +132,9 @@ QStringList Vizkit3DConfig::getAvailableCameraManipulators() const
 {
     QString current = manipulatorIDToName(getWidget()->getCameraManipulator());
     QStringList names;
+    names.append(current);
     for (int i = 0; KNOWN_MANIPULATORS[i].name != 0; ++i)
-    {
-        QString n = KNOWN_MANIPULATORS[i].name;
-        if (n == current)
-            names.prepend(n);
-        else
-            names.append(n);
-    }
+        names.append(KNOWN_MANIPULATORS[i].name);
     return names;
 }
 

--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -65,12 +65,7 @@ void Vizkit3DConfig::setAxes(bool value)
 QStringList Vizkit3DConfig::getVisualizationFrames() const
 {
     QStringList frames = getWidget()->getVisualizationFrames();
-    QString current = getWidget()->getVisualizationFrame();
-    if (!current.isEmpty() && !frames.isEmpty())
-    {
-        frames.removeOne(current);
-        frames.prepend(current);
-    }
+    frames.push_front(getWidget()->getVisualizationFrame());
     return frames;
 }
 
@@ -130,11 +125,23 @@ namespace
 
 QStringList Vizkit3DConfig::getAvailableCameraManipulators() const
 {
-    QString current = manipulatorIDToName(getWidget()->getCameraManipulator());
     QStringList names;
-    names.append(current);
     for (int i = 0; KNOWN_MANIPULATORS[i].name != 0; ++i)
-        names.append(KNOWN_MANIPULATORS[i].name);
+    {
+        if (KNOWN_MANIPULATORS[i].is_public)
+            names.append(KNOWN_MANIPULATORS[i].name);
+    }
+
+    QString current = getWidget()->getCameraManipulatorName();
+    // When using the node tracker, the visualization frame name is not part of
+    // the list of available frames. Add it at the back to ensure the qt
+    // property browser handles it properly
+    if (!names.contains(current))
+        names.push_back(current);
+
+    // The first element of the list is interpreted as the currently selected
+    // frame by the property browser
+    names.push_front(current);
     return names;
 }
 

--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -982,6 +982,8 @@ void Vizkit3DWidget::setCameraManipulator(CAMERA_MANIPULATORS manipulatorType, b
         case MULTI_TOUCH_TRACKBALL_MANIPULATOR:
             newManipulator = new osgGA::MultiTouchTrackballManipulator;
             break;
+        default:
+            throw std::invalid_argument("invalid camera manipulator type provided");
     };
 
     setCameraManipulator(newManipulator);

--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -27,6 +27,7 @@
 
 #include <osgGA/FirstPersonManipulator>
 #include <osgGA/FlightManipulator>
+#include <osgGA/OrbitManipulator>
 #include <osgGA/NodeTrackerManipulator>
 #include <osgGA/TerrainManipulator>
 #include <osgGA/TrackballManipulator>
@@ -978,7 +979,7 @@ void Vizkit3DWidget::setCameraManipulator(CAMERA_MANIPULATORS manipulatorType, b
             newManipulator = new osgGA::FlightManipulator;
             break;
         case ORBIT_MANIPULATOR:
-            newManipulator = new osgGA::FlightManipulator;
+            newManipulator = new osgGA::OrbitManipulator;
             break;
         case TERRAIN_MANIPULATOR:
             newManipulator = new osgGA::TerrainManipulator;

--- a/src/Vizkit3DWidget.hpp
+++ b/src/Vizkit3DWidget.hpp
@@ -238,8 +238,14 @@ namespace vizkit3d
             QObject* loadPlugin(QString lib_name,QString plugin_name);
             QStringList* getAvailablePlugins();
 
+            /** @overload sets the camera manipulator by name */
+            void setCameraManipulator(QString manipulator, bool resetToDefaultHome = false);
             /** Sets the current camera manipulator among those available */
             void setCameraManipulator(CAMERA_MANIPULATORS manipulator, bool resetToDefaultHome = false);
+            /** @overload returns the name of the current camera manipulator
+             * (needed for the Ruby bindings
+             */
+            QString getCameraManipulatorName() const;
             /** Returns the current camera manipulator */
             CAMERA_MANIPULATORS getCameraManipulator() const;
 

--- a/src/Vizkit3DWidget.hpp
+++ b/src/Vizkit3DWidget.hpp
@@ -112,7 +112,8 @@ namespace vizkit3d
             void setVisualizationFrame(const QString &frame,bool update=true);
 
             // we have to use a pointer here otherwise qt ruby is crashing
-            QStringList* getVisualizationFrames() const;
+            QStringList* getVisualizationFramesRuby() const;
+            QStringList getVisualizationFrames() const;
             QString getVisualizationFrame() const;
 
             /**

--- a/src/Vizkit3DWidget.hpp
+++ b/src/Vizkit3DWidget.hpp
@@ -11,6 +11,8 @@
 namespace osgQt { class GraphicsWindowQt;}
 namespace vizkit3d
 {
+    class Vizkit3DWidget;
+
     // configuration class
     class Vizkit3DConfig :public QObject
     {
@@ -22,7 +24,8 @@ namespace vizkit3d
         Q_PROPERTY( bool transformer READ isTransformer WRITE setTransformer)
 
         public:
-            Vizkit3DConfig(QObject *parent);
+            Vizkit3DConfig(Vizkit3DWidget *parent);
+            Vizkit3DWidget* getWidget() const;
 
         signals:
             void propertyChanged(QString);

--- a/src/Vizkit3DWidget.hpp
+++ b/src/Vizkit3DWidget.hpp
@@ -22,11 +22,76 @@ namespace vizkit3d
      */
     enum CAMERA_MANIPULATORS
     {
+        /**
+         * Wheel controls forward/backward movement, in the direction of the
+         * camera. Left button + mouse movement controls pitch and yaw.
+         *
+         * The value given to setWheelMovement is the scale factor between the
+         * wheel movement and the actual movement in the scene. It defaults to
+         * 0.05. There is also a way to force centering the camera on the
+         * current mouse pointer position whenever the wheel is used by giving
+         * the SET_CENTER_ON_WHEEL_FORWARD_MOVEMENT flag to the constructor. The
+         * centering is animated (i.e. not abrupt) and the animation step is
+         * controlled by setAnimationTime
+         *
+         * If vertical axis is fixed (the default), the rotation maintain the
+         * "up" vector. Otherwise, they don't. It can be changed with
+         * setVerticalAxisFixed.
+         */
         FIRST_PERSON_MANIPULATOR,
+        /** Behaves like a flight simulator controlled by a mouse. The position
+         * of the mouse w.r.t. the center of the window causes pitch/roll. By
+         * default (can be turned off), yaw is also changed if the camera banked
+         * (has non-zero roll).
+         *
+         * In addition, the camera has a velocity and moves continuously if this
+         * velocity is non-zero. The left mouse button causes the camera's
+         * velocity to grow, the right mouse to decrease and the middle mouse
+         * button sets it to zero.
+         */
         FLIGHT_MANIPULATOR,
+        /** Transforms the camera as if it was "orbiting" a point of reference
+         * (the camera center).
+         *
+         * The mouse wheel applies a scale factor on the distance between the
+         * camera eye and the center, as 1.0 + wheelZoomFactor (regardless of
+         * the actual wheel movement). The default wheelZoomFactor is 0.1. If
+         * this distance becomes smaller than a minimum distance (defaults to
+         * 0.05), the center gets "pushed" forward so that the minimum distance
+         * is kept. In practice, it means that the wheel movement is huge when
+         * far from the center and tiny when close.
+         *
+         * Moving the mouse with the left mouse button pressed does a trackball
+         * rotation, i.e. makes the camera move "as if" the mouse moved a sphere
+         * centered on the center point. By default, the orbit manipulator
+         * constrains the vertical axis to keep within the same plane (i.e.
+         * vertical is always vertical)
+         *
+         * Moving the mouse with the right mouse button pressed also applies a
+         * zoom (following the same rules). The scale factor applied is the
+         * movement in Y, 1.0 seems to be the whole height of the window.
+         *
+         * Moving the mouse with the middle mouse button pressed applies a panning
+         * movement. The movement is displacement * 0.3 * distance_to_center
+         */
         ORBIT_MANIPULATOR,
+        /** Like an orbit manipulator, with the middle-button behaviour changed
+         *
+         * If the mouse is moved while the middle button is pressed, X movement
+         * moves the center in the camera's side direction and Y movement
+         * moves it in the forward direction. The movement in each case is 0.3 *
+         * distance_to_center * distance_moved. In addition, if a node is
+         * associated with the camera, the center will "track" the node's shape,
+         * i.e. an intersection is computed and the distance-to-node kept.
+         */
         TERRAIN_MANIPULATOR,
+        /** Just like an orbit manipulator, but with the fixed-vertical-axis
+         * constraint set to false by default
+         */
         TRACKBALL_MANIPULATOR,
+        /** Like the trackball manipulator, but reacts to pinch-to-zoom vs. drag
+         * multitouch events.
+         */
         MULTI_TOUCH_TRACKBALL_MANIPULATOR
     };
 

--- a/src/qtpropertybrowser/qtpropertymanager.h
+++ b/src/qtpropertybrowser/qtpropertymanager.h
@@ -1063,7 +1063,7 @@ public:
 
 public Q_SLOTS:
     void setValue(QtProperty *property, int val);
-    void setEnumNames(QtProperty *property, const QStringList &names);
+    void setEnumNames(QtProperty *property, QStringList names);
     void setEnumIcons(QtProperty *property, const QMap<int, QIcon> &icons);
 Q_SIGNALS:
     void valueChanged(QtProperty *property, int val);


### PR DESCRIPTION
This set of commits cleans up some of the most gruesome aspects of Vizkit3DWidget,
adds accessors and properties allowing to change the manipulator and gives this access
to these from Ruby.

It also documents the behaviour of the accessors within the enum ... Went through them in the
OSG codebase.