### PR TITLE
Default manipulator

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ rock_library(vizkit3d
         OsgVisitors.cpp
         TransformerGraph.cpp
         CoordinateFrame.cpp
+        DefaultManipulator.cpp
         EnableGLDebugOperation.cpp
         ${PROPERTY_BROWSER_RESOURCES} 
     MOC
@@ -50,6 +51,7 @@ rock_library(vizkit3d
         ColorConversionHelper.hpp
         CoordinateFrame.hpp
         EnvPluginBase.hpp
+        DefaultManipulator.hpp
         ${HEADERS_EXTRA}
     LIBS ${Boost_THREAD_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${OPENSCENEGRAPH_LIBRARIES}
     DEPS_CMAKE OpenGL

--- a/src/DefaultManipulator.cpp
+++ b/src/DefaultManipulator.cpp
@@ -1,0 +1,20 @@
+#include <vizkit3d/DefaultManipulator.hpp>
+
+using namespace vizkit3d;
+
+DefaultManipulator::DefaultManipulator()
+{
+    setWheelMovement(10.0, false);
+}
+
+// doc in parent
+bool DefaultManipulator::performMovementRightMouseButton( const double eventTimeDelta, const double dx, const double dy )
+{
+    // pan model
+    float scale = 10.0f;
+
+    moveRight(-scale * dx);
+    moveUp(scale * dy);
+    return true;
+}
+

--- a/src/DefaultManipulator.cpp
+++ b/src/DefaultManipulator.cpp
@@ -4,7 +4,7 @@ using namespace vizkit3d;
 
 DefaultManipulator::DefaultManipulator()
 {
-    setWheelMovement(10.0, false);
+    setWheelMovement(1.0, false);
 }
 
 // doc in parent

--- a/src/DefaultManipulator.cpp
+++ b/src/DefaultManipulator.cpp
@@ -14,7 +14,7 @@ bool DefaultManipulator::performMovementRightMouseButton( const double eventTime
     float scale = 10.0f;
 
     moveRight(-scale * dx);
-    moveUp(scale * dy);
+    moveUp(-scale * dy);
     return true;
 }
 

--- a/src/DefaultManipulator.hpp
+++ b/src/DefaultManipulator.hpp
@@ -1,0 +1,35 @@
+#ifndef VIZKIT3D_DEFAULT_MANIPULATOR_HPP
+#define VIZKIT3D_DEFAULT_MANIPULATOR_HPP
+
+#include <osgGA/FirstPersonManipulator>
+
+namespace vizkit3d
+{
+    /** Vizkit3d's default manipulator
+     *
+     * The wheel controls forward/backward movement, in the direction of the
+     * camera. Left button + mouse movement controls pitch and yaw. Right
+     * button + mouse movement pans.
+     *
+     * The value given to setWheelMovement is the scale factor between the
+     * wheel movement and the actual movement in the scene. It defaults to
+     * 0.05. There is also a way to force centering the camera on the
+     * current mouse pointer position whenever the wheel is used by giving
+     * the SET_CENTER_ON_WHEEL_FORWARD_MOVEMENT flag to the constructor. The
+     * centering is animated (i.e. not abrupt) and the animation step is
+     * controlled by setAnimationTime
+     *
+     * If vertical axis is fixed (the default), the rotation maintain the
+     * "up" vector. Otherwise, they don't. It can be changed with
+     * setVerticalAxisFixed.
+     */
+    class DefaultManipulator : public osgGA::FirstPersonManipulator
+    {
+    public:
+        DefaultManipulator();
+        bool performMovementRightMouseButton( const double eventTimeDelta, const double dx, const double dy );
+    };
+}
+
+#endif
+

--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -26,6 +26,7 @@
 #include <osgQt/GraphicsWindowQt>
 #include <osgViewer/ViewerEventHandlers>
 
+#include <vizkit3d/DefaultManipulator.hpp>
 #include <osgGA/FirstPersonManipulator>
 #include <osgGA/FlightManipulator>
 #include <osgGA/OrbitManipulator>
@@ -136,6 +137,7 @@ namespace
         bool is_public;
     };
     ManipulatorDefinition KNOWN_MANIPULATORS[] = {
+        { "Default", DEFAULT_MANIPULATOR, true },
         { "First Person", FIRST_PERSON_MANIPULATOR, true },
         { "Flight", FLIGHT_MANIPULATOR, true },
         { "Multi Touch Trackball", MULTI_TOUCH_TRACKBALL_MANIPULATOR, true },
@@ -1101,6 +1103,9 @@ void Vizkit3DWidget::setCameraManipulator(CAMERA_MANIPULATORS manipulatorType, b
     osg::ref_ptr<osgGA::CameraManipulator> newManipulator;
     switch(manipulatorType)
     {
+        case DEFAULT_MANIPULATOR:
+            newManipulator = new vizkit3d::DefaultManipulator;
+            break;
         case FIRST_PERSON_MANIPULATOR:
             newManipulator = new osgGA::FirstPersonManipulator;
             break;

--- a/src/Vizkit3DWidget.hpp
+++ b/src/Vizkit3DWidget.hpp
@@ -25,6 +25,24 @@ namespace vizkit3d
     {
         /**
          * Wheel controls forward/backward movement, in the direction of the
+         * camera. Left button + mouse movement controls pitch and yaw. Right
+         * button + mouse movement pans.
+         *
+         * The value given to setWheelMovement is the scale factor between the
+         * wheel movement and the actual movement in the scene. It defaults to
+         * 0.05. There is also a way to force centering the camera on the
+         * current mouse pointer position whenever the wheel is used by giving
+         * the SET_CENTER_ON_WHEEL_FORWARD_MOVEMENT flag to the constructor. The
+         * centering is animated (i.e. not abrupt) and the animation step is
+         * controlled by setAnimationTime
+         *
+         * If vertical axis is fixed (the default), the rotation maintain the
+         * "up" vector. Otherwise, they don't. It can be changed with
+         * setVerticalAxisFixed.
+         */
+        DEFAULT_MANIPULATOR,
+        /**
+         * Wheel controls forward/backward movement, in the direction of the
          * camera. Left button + mouse movement controls pitch and yaw.
          *
          * The value given to setWheelMovement is the scale factor between the


### PR DESCRIPTION
DO NOT MERGE: this depends on #10 

This creates an arguably better default manipulator for vizkit3d. It keeps the same general behaviour
(i.e. mouse actions vs. camera movement) than the terrain manipulator, but removes the need for a
terrain.

It is IMO better as the terrain manipulator is basically useful only if you *have* a terrain. For any other application as e.g. underwater, flying, looking at the [transformer graph](rock-core/gui-vizkit#18), it is
only a huge exercise in frustration. As it is still very usable in the terrain case, I don't think that it would
be a major drawback to make it the default (hence its name)