### PR TITLE
fix transform graph incremental update when both nodes in a new link have parents

### DIFF
--- a/src/TransformerGraph.hpp
+++ b/src/TransformerGraph.hpp
@@ -105,6 +105,11 @@ namespace vizkit3d
         static bool setTransformation(osg::Node &transformer,const std::string &source_frame,const std::string &target_frame,
                                       const osg::Quat &quat, const osg::Vec3d &trans);
 
+        /** Ensures that the transform node for the given frame is a direct
+         * child of the transformer node
+         */
+        static void makeRoot(osg::Node& transformer, std::string const& desiredRoot);
+
         /**
          * Gets the transformation between two coordinate frames. Thereby unlike setTransformation the frames do not have to be subsequently.
          *

--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -686,6 +686,15 @@ void Vizkit3DWidget::setTransformation(const QString &source_frame,const QString
         for(;it != plugins.end();++it)
             it->first->setVisualizationFrame(it->first->getVisualizationFrame());
     }
+
+    if (!root_frame.isEmpty());
+        TransformerGraph::makeRoot(*getRootNode(), root_frame.toStdString());
+}
+
+void Vizkit3DWidget::setRootFrame(QString frame)
+{
+    TransformerGraph::makeRoot(*getRootNode(), frame.toStdString());
+    root_frame = frame;
 }
 
 void Vizkit3DWidget::getTransformation(const QString &source_frame,const QString &target_frame, QVector3D &position, QQuaternion &orientation)const

--- a/src/Vizkit3DWidget.hpp
+++ b/src/Vizkit3DWidget.hpp
@@ -68,6 +68,10 @@ namespace vizkit3d
             ///The frame in which the data should be displayed
             void setVisualizationFrame(const QString &frame,bool update=true);
 
+            /** Require the given frame to be directly attached to the root
+             */
+            void setRootFrame(QString frame);
+
             // we have to use a pointer here otherwise qt ruby is crashing
             QStringList* getVisualizationFrames() const;
             QString getVisualizationFrame() const;
@@ -162,6 +166,9 @@ namespace vizkit3d
         private:
             //holds the scene
             osg::ref_ptr<osg::Group> root;
+
+            // The name of a frame that should be directly attached to osg_world
+            QString root_frame;
 
             /** The set of known plugins, as a mapping from the plugin to the osg::Node
              * to which it should be attached.

--- a/test/testTransformerGraph.cpp
+++ b/test/testTransformerGraph.cpp
@@ -47,6 +47,59 @@ BOOST_AUTO_TEST_CASE(it_keeps_existing_links_even_if_updates_are_provided_revers
     REQUIRE_SAME_GRAPH(expected_graph, root);
 }
 
+BOOST_AUTO_TEST_CASE(it_allows_to_make_a_frame_root)
+{
+    NodePtr root(TransformerGraph::create("root"));
+
+    TransformerGraph::setTransformation(*root, "frame1", "frame2", Identity, Zero);
+    TransformerGraph::setTransformation(*root, "frame1", "frame3", Identity, Zero);
+    TransformerGraph::setTransformation(*root, "frame2", "frame4", Identity, Zero);
+    TransformerGraph::makeRoot(*root, "frame2");
+
+    char const* expected_graph[] = {
+        "root", "frame2",
+        "frame2", "frame1",
+        "frame1", "frame3",
+        "frame2", "frame4"
+    };
+    REQUIRE_SAME_GRAPH(expected_graph, root);
+}
+
+BOOST_AUTO_TEST_CASE(it_automatically_changes_the_node_shape_when_needed)
+{
+    NodePtr root(TransformerGraph::create("root"));
+
+    TransformerGraph::setTransformation(*root, "frame1", "frame2", Identity, Zero);
+    TransformerGraph::setTransformation(*root, "frame3", "frame4", Identity, Zero);
+    TransformerGraph::setTransformation(*root, "frame2", "frame4", Identity, Zero);
+
+    char const* expected_graph[] = {
+        "root", "frame1",
+        "frame1", "frame2",
+        "frame2", "frame4",
+        "frame4", "frame3"
+    };
+    REQUIRE_SAME_GRAPH(expected_graph, root);
+}
+
+BOOST_AUTO_TEST_CASE(it_handles_loops_gracefully_when_reshaping)
+{
+    NodePtr root(TransformerGraph::create("root"));
+
+    TransformerGraph::setTransformation(*root, "frame1", "frame2", Identity, Zero);
+    TransformerGraph::setTransformation(*root, "frame2", "frame3", Identity, Zero);
+    TransformerGraph::setTransformation(*root, "frame3", "frame4", Identity, Zero);
+    TransformerGraph::setTransformation(*root, "frame4", "frame2", Identity, Zero);
+
+    char const* expected_graph[] = {
+        "root", "frame3",
+        "frame3", "frame4",
+        "frame4", "frame2",
+        "frame2", "frame1"
+    };
+    REQUIRE_SAME_GRAPH(expected_graph, root);
+}
+
 BOOST_AUTO_TEST_SUITE_END();
 
 


### PR DESCRIPTION
This was the last use case not covered by the last patches on
the subject, namely the case where we have something like:

  f1 -> f2
  f3 -> f4

and the user adds f2 -> f4. Or, worse,

  f1 -> f2
  f1 -> f3

and the user adds f3 -> f2. This last case is invalid, but can easily
happen in bigger graphs if the user is editing its transformer
configuration file (as opposed to only load a known transform file).

This commit reshapes the graph to invert the "child" parts, making
sure that it does not create cycles.

It also adds a setRoot accessor that allows to specify which frame
should be attached to osg_world. It being random is really annoying. 