### PR TITLE
Improve grabbing

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ QT4_ADD_RESOURCES(PROPERTY_BROWSER_RESOURCES qtpropertybrowser/qtpropertybrowser
 
 rock_library(vizkit3d
     SOURCES
+        WindowCaptureCallback.cpp
         QtThreadedWidget.cpp
         NodeLink.cpp
         ColorConversionHelper.cpp

--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -34,6 +34,8 @@
 #include <osgGA/TrackballManipulator>
 #include <osgGA/MultiTouchTrackballManipulator>
 
+#include <vizkit3d/WindowCaptureCallback.hpp>
+
 using namespace vizkit3d;
 using namespace std;
 
@@ -279,12 +281,12 @@ QString Vizkit3DWidget::getVisualizationFrame() const
     return current_frame;
 }
 
-struct CaptureOperation : public osgViewer::ScreenCaptureHandler::CaptureOperation
+struct ImageGrabOperation : public vizkit3d::CaptureOperation
 {
     uint64_t frame_id;
     QImage image;
 
-    CaptureOperation()
+    ImageGrabOperation()
         : frame_id(0) {}
 
     void operator()(const osg::Image& image, const unsigned int)
@@ -296,46 +298,62 @@ struct CaptureOperation : public osgViewer::ScreenCaptureHandler::CaptureOperati
             qtFormat = QImage::Format_RGB888;
         else if (image.getPixelFormat() == GL_BGRA)
             qtFormat = QImage::Format_ARGB32;
-        else if (image.getPixelFormat() == GL_RGB)
-            qtFormat = QImage::Format_RGB888;
-        else if (image.getPixelFormat() == GL_RGBA)
-            qtFormat = QImage::Format_ARGB32;
         else
             throw std::runtime_error("cannot interpret osg-provided image format " +
                     boost::lexical_cast<std::string>(image.getPixelFormat()));
 
-        this->image = QImage(image.data(), image.s(), image.t(), qtFormat);
+        QImage img(image.data(), image.s(), image.t(), qtFormat);
+        this->image = img.mirrored(false, true);
     }
-
 };
 
-void Vizkit3DWidget::enableGrabbing()
+void Vizkit3DWidget::enableGrabbing(GrabbingMode mode)
 {
-    if (captureHandler)
+    if (captureCallback)
         return;
 
-    CaptureOperation* op = new CaptureOperation;
+    WindowCaptureCallback* callback = new WindowCaptureCallback(-1,
+            mode, WindowCaptureCallback::END_FRAME, GL_BACK, GL_BGR);
+    ImageGrabOperation* op = new ImageGrabOperation;
+    callback->setCaptureOperation(op);
+
+    captureCallback  = callback;
     captureOperation = op;
-    captureHandler   = new osgViewer::ScreenCaptureHandler(op, 1);
+
+    // If in multi-pbo mode, we have to grab a few frames "for starter" to make
+    // sure that grab() will always return a valid image
+    int count = 0;
+    if (mode == DOUBLE_PBO)
+        count = 1;
+    else if (mode == TRIPLE_PBO)
+        count = 2;
+    if (count > 0)
+    {
+        getView(0)->getCamera()->setFinalDrawCallback(captureCallback);
+        for (int i = 0; i < count; ++i)
+            frame();
+        getView(0)->getCamera()->setFinalDrawCallback(0);
+    }
 }
 
 void Vizkit3DWidget::disableGrabbing()
 {
     captureOperation = NULL;
-    captureHandler = NULL;
+    captureCallback = NULL;
 }
 
 QImage Vizkit3DWidget::grab()
 {
-    if (!captureHandler)
+    if (!captureCallback)
     {
         qWarning("you must call enableGrabbing() before grab()");
         return QImage();
     }
 
-    dynamic_cast<osgViewer::ScreenCaptureHandler&>(*captureHandler).captureNextFrame(*this);
+    getView(0)->getCamera()->setFinalDrawCallback(captureCallback);
     frame();
-    return static_cast<CaptureOperation&>(*captureOperation).image;
+    getView(0)->getCamera()->setFinalDrawCallback(0);
+    return static_cast<ImageGrabOperation&>(*captureOperation).image;
 };
 
 QWidget* Vizkit3DWidget::addViewWidget( osgQt::GraphicsWindowQt* gw, ::osg::Node* scene )

--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -199,7 +199,7 @@ void Vizkit3DConfig::setCameraManipulator(QStringList const& manipulator)
     return getWidget()->setCameraManipulator(id);
 }
 
-Vizkit3DWidget::Vizkit3DWidget( QWidget* parent,const QString &world_name)
+Vizkit3DWidget::Vizkit3DWidget( QWidget* parent,const QString &world_name,bool auto_update)
     : QWidget(parent)
     , env_plugin(NULL)
 {
@@ -253,7 +253,8 @@ Vizkit3DWidget::Vizkit3DWidget( QWidget* parent,const QString &world_name)
     current_frame = QString(root->getName().c_str());
 
     //start timer responsible for updating osg viewer
-    _timer.start(10);
+    if (auto_update)
+        _timer.start(10);
 }
 
 Vizkit3DWidget::~Vizkit3DWidget() {}

--- a/src/Vizkit3DWidget.hpp
+++ b/src/Vizkit3DWidget.hpp
@@ -167,7 +167,7 @@ namespace vizkit3d
             static osg::Vec3d const DEFAULT_UP;
 
             friend class VizPluginBase;
-            Vizkit3DWidget(QWidget* parent = 0,const QString &world_name = "world_osg");
+            Vizkit3DWidget(QWidget* parent = 0,const QString &world_name = "world_osg",bool auto_update = true);
 
             /** Defined to avoid unnecessary dependencies in the headers
              *

--- a/src/Vizkit3DWidget.hpp
+++ b/src/Vizkit3DWidget.hpp
@@ -200,6 +200,14 @@ namespace vizkit3d
              */
             void setCameraManipulator(osg::ref_ptr<osgGA::CameraManipulator> manipulator, bool resetToDefaultHome = false);
 
+            enum GrabbingMode {
+                READ_PIXELS,
+                SINGLE_PBO,
+                DOUBLE_PBO,
+                TRIPLE_PBO
+            };
+
+
         public slots:
             void addPlugin(QObject* plugin, QObject* parent = NULL);
             void removePlugin(QObject* plugin);
@@ -264,11 +272,12 @@ namespace vizkit3d
 
             bool isAxesLabels() const;
             void setAxesLabels(bool value);
+
             /** Enables grabbing
              *
              * Must be called before grab()
              */
-            void enableGrabbing();
+            void enableGrabbing(GrabbingMode mode = SINGLE_PBO);
             /** Disables grabbing
              *
              * You will have to call enableGrabbing() again before you can use
@@ -396,7 +405,7 @@ namespace vizkit3d
             CAMERA_MANIPULATORS last_manipulator;
             CAMERA_MANIPULATORS current_manipulator;
 
-            osg::ref_ptr<osg::Referenced> captureHandler;
+            osg::ref_ptr<osg::Camera::DrawCallback> captureCallback;
             osg::ref_ptr<osg::Referenced> captureOperation;
     };
 }

--- a/src/Vizkit3DWidget.hpp
+++ b/src/Vizkit3DWidget.hpp
@@ -395,6 +395,9 @@ namespace vizkit3d
 
             CAMERA_MANIPULATORS last_manipulator;
             CAMERA_MANIPULATORS current_manipulator;
+
+            osg::ref_ptr<osg::Referenced> captureHandler;
+            osg::ref_ptr<osg::Referenced> captureOperation;
     };
 }
 #endif

--- a/src/WindowCaptureCallback.cpp
+++ b/src/WindowCaptureCallback.cpp
@@ -1,0 +1,427 @@
+/* -*-c++-*- OpenSceneGraph - Copyright (C) 1998-2006 Robert Osfield
+*
+* This library is open source and may be redistributed and/or modified under
+* the terms of the OpenSceneGraph Public License (OSGPL) version 0.0 or
+* (at your option) any later version.  The full license is in LICENSE file
+* included with this distribution, and on the openscenegraph.org website.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* OpenSceneGraph Public License for more details.
+*/
+
+#include <vizkit3d/WindowCaptureCallback.hpp>
+#include <osg/RenderInfo>
+
+#include <iostream>
+
+namespace vizkit3d
+{
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  WindowCaptureCallback
+//
+
+// From osgscreencapture example
+/** Callback which will be added to a viewer's camera to do the actual screen capture. */
+WindowCaptureCallback::ContextData::ContextData(osg::GraphicsContext* gc, Mode mode, GLenum readBuffer, GLint pixelFormat)
+    : _gc(gc),
+      _index(_gc->getState()->getContextID()),
+      _mode(mode),
+      _readBuffer(readBuffer),
+      _pixelFormat(pixelFormat),
+      _type(GL_UNSIGNED_BYTE),
+      _width(0),
+      _height(0),
+      _currentImageIndex(0),
+      _currentPboIndex(0),
+      _reportTimingFrequency(100),
+      _numTimeValuesRecorded(0),
+      _timeForReadPixels(0.0),
+      _timeForMemCpy(0.0),
+      _timeForCaptureOperation(0.0),
+      _timeForFullCopy(0.0),
+      _timeForFullCopyAndOperation(0.0),
+      _previousFrameTick(0)
+{
+    _previousFrameTick = osg::Timer::instance()->tick();
+
+    osg::NotifySeverity level = osg::INFO;
+
+    if (gc->getTraits())
+    {
+        if (gc->getTraits()->alpha)
+        {
+            _pixelFormat |= 1;
+        }
+        else
+        {
+            OSG_NOTIFY(level)<<"WindowCaptureCallback: Selected GL_RGB read back format"<<std::endl;
+            _pixelFormat = _pixelFormat & 0xFFFE;
+        }
+    }
+
+    getSize(gc, _width, _height);
+
+    //OSG_NOTICE<<"Window size "<<_width<<", "<<_height<<std::endl;
+
+    // single buffered image
+    _imageBuffer.push_back(new osg::Image);
+
+    // double buffer PBO.
+    switch(_mode)
+    {
+        case(Vizkit3DWidget::READ_PIXELS):
+            OSG_NOTIFY(level)<<"WindowCaptureCallback: Reading window using glReadPixels, without PixelBufferObject."<<std::endl;
+            break;
+        case(Vizkit3DWidget::SINGLE_PBO):
+            OSG_NOTIFY(level)<<"WindowCaptureCallback: Reading window using glReadPixels, with a single PixelBufferObject."<<std::endl;
+            _pboBuffer.push_back(0);
+            break;
+        case(Vizkit3DWidget::DOUBLE_PBO):
+            OSG_NOTIFY(level)<<"WindowCaptureCallback: Reading window using glReadPixels, with a double buffer PixelBufferObject."<<std::endl;
+            _pboBuffer.push_back(0);
+            _pboBuffer.push_back(0);
+            break;
+        case(Vizkit3DWidget::TRIPLE_PBO):
+            OSG_NOTIFY(level)<<"WindowCaptureCallback: Reading window using glReadPixels, with a triple buffer PixelBufferObject."<<std::endl;
+            _pboBuffer.push_back(0);
+            _pboBuffer.push_back(0);
+            _pboBuffer.push_back(0);
+            break;
+        default:
+            break;
+    }
+}
+
+void WindowCaptureCallback::ContextData::getSize(osg::GraphicsContext* gc, int& width, int& height)
+{
+    if (gc->getTraits())
+    {
+        width = gc->getTraits()->width;
+        height = gc->getTraits()->height;
+    }
+}
+
+void WindowCaptureCallback::ContextData::updateTimings(osg::Timer_t tick_start,
+                                                       osg::Timer_t tick_afterReadPixels,
+                                                       osg::Timer_t tick_afterMemCpy,
+                                                       osg::Timer_t tick_afterCaptureOperation,
+                                                       unsigned int /*dataSize*/)
+{
+    _timeForReadPixels = osg::Timer::instance()->delta_s(tick_start, tick_afterReadPixels);
+    _timeForMemCpy = osg::Timer::instance()->delta_s(tick_afterReadPixels, tick_afterMemCpy);
+    _timeForCaptureOperation = osg::Timer::instance()->delta_s(tick_afterMemCpy, tick_afterCaptureOperation);
+
+    _timeForFullCopy = osg::Timer::instance()->delta_s(tick_start, tick_afterMemCpy);
+    _timeForFullCopyAndOperation = osg::Timer::instance()->delta_s(tick_start, tick_afterCaptureOperation);
+}
+
+void WindowCaptureCallback::ContextData::read()
+{
+    osg::GLBufferObject::Extensions* ext = osg::GLBufferObject::getExtensions(_gc->getState()->getContextID(),true);
+
+    if (ext->isPBOSupported() && !_pboBuffer.empty())
+    {
+        if (_pboBuffer.size()==1)
+        {
+            singlePBO(ext);
+        }
+        else
+        {
+            multiPBO(ext);
+        }
+    }
+    else
+    {
+        readPixels();
+    }
+}
+
+
+void WindowCaptureCallback::ContextData::readPixels()
+{
+    unsigned int nextImageIndex = (_currentImageIndex+1)%_imageBuffer.size();
+    unsigned int nextPboIndex = _pboBuffer.empty() ? 0 : (_currentPboIndex+1)%_pboBuffer.size();
+
+    int width=0, height=0;
+    getSize(_gc, width, height);
+    if (width!=_width || _height!=height)
+    {
+        //OSG_NOTICE<<"   Window resized "<<width<<", "<<height<<std::endl;
+        _width = width;
+        _height = height;
+    }
+
+    osg::Image* image = _imageBuffer[_currentImageIndex].get();
+
+    osg::Timer_t tick_start = osg::Timer::instance()->tick();
+
+#if 1
+    image->readPixels(0,0,_width,_height,
+                      _pixelFormat,_type);
+#endif
+
+    osg::Timer_t tick_afterReadPixels = osg::Timer::instance()->tick();
+
+    if (_captureOperation.valid())
+    {
+        (*_captureOperation)(*image, _index);
+    }
+
+    osg::Timer_t tick_afterCaptureOperation = osg::Timer::instance()->tick();
+    updateTimings(tick_start, tick_afterReadPixels, tick_afterReadPixels, tick_afterCaptureOperation, image->getTotalSizeInBytes());
+
+    _currentImageIndex = nextImageIndex;
+    _currentPboIndex = nextPboIndex;
+}
+
+void WindowCaptureCallback::ContextData::singlePBO(osg::GLBufferObject::Extensions* ext)
+{
+    unsigned int nextImageIndex = (_currentImageIndex+1)%_imageBuffer.size();
+
+    int width=0, height=0;
+    getSize(_gc, width, height);
+    if (width!=_width || _height!=height)
+    {
+        //OSG_NOTICE<<"   Window resized "<<width<<", "<<height<<std::endl;
+        _width = width;
+        _height = height;
+    }
+
+    GLuint& pbo = _pboBuffer[0];
+
+    osg::Image* image = _imageBuffer[_currentImageIndex].get();
+    if (image->s() != _width ||
+        image->t() != _height)
+    {
+        //OSG_NOTICE<<"WindowCaptureCallback: Allocating image "<<std::endl;
+        image->allocateImage(_width, _height, 1, _pixelFormat, _type);
+
+        if (pbo!=0)
+        {
+            //OSG_NOTICE<<"WindowCaptureCallback: deleting pbo "<<pbo<<std::endl;
+            ext->glDeleteBuffers (1, &pbo);
+            pbo = 0;
+        }
+    }
+
+
+    if (pbo==0)
+    {
+        ext->glGenBuffers(1, &pbo);
+        ext->glBindBuffer(GL_PIXEL_PACK_BUFFER_ARB, pbo);
+        ext->glBufferData(GL_PIXEL_PACK_BUFFER_ARB, image->getTotalSizeInBytes(), 0, GL_STREAM_READ);
+
+        //OSG_NOTICE<<"WindowCaptureCallback: Generating pbo "<<pbo<<std::endl;
+    }
+    else
+    {
+        ext->glBindBuffer(GL_PIXEL_PACK_BUFFER_ARB, pbo);
+    }
+
+    osg::Timer_t tick_start = osg::Timer::instance()->tick();
+
+#if 1
+    glReadPixels(0, 0, _width, _height, _pixelFormat, _type, 0);
+#endif
+
+    osg::Timer_t tick_afterReadPixels = osg::Timer::instance()->tick();
+
+    GLubyte* src = (GLubyte*)ext->glMapBuffer(GL_PIXEL_PACK_BUFFER_ARB,
+                                              GL_READ_ONLY_ARB);
+    if(src)
+    {
+        memcpy(image->data(), src, image->getTotalSizeInBytes());
+        ext->glUnmapBuffer(GL_PIXEL_PACK_BUFFER_ARB);
+    }
+
+    ext->glBindBuffer(GL_PIXEL_PACK_BUFFER_ARB, 0);
+
+    osg::Timer_t tick_afterMemCpy = osg::Timer::instance()->tick();
+
+    if (_captureOperation.valid())
+    {
+        (*_captureOperation)(*image, _index);
+    }
+
+    osg::Timer_t tick_afterCaptureOperation = osg::Timer::instance()->tick();
+    updateTimings(tick_start, tick_afterReadPixels, tick_afterMemCpy, tick_afterCaptureOperation, image->getTotalSizeInBytes());
+
+    _currentImageIndex = nextImageIndex;
+}
+
+void WindowCaptureCallback::ContextData::multiPBO(osg::GLBufferObject::Extensions* ext)
+{
+    unsigned int nextImageIndex = (_currentImageIndex+1)%_imageBuffer.size();
+    unsigned int nextPboIndex = (_currentPboIndex+1)%_pboBuffer.size();
+
+    int width=0, height=0;
+    getSize(_gc, width, height);
+    if (width!=_width || _height!=height)
+    {
+        //OSG_NOTICE<<"   Window resized "<<width<<", "<<height<<std::endl;
+        _width = width;
+        _height = height;
+    }
+
+    GLuint& copy_pbo = _pboBuffer[_currentPboIndex];
+    GLuint& read_pbo = _pboBuffer[nextPboIndex];
+
+    osg::Image* image = _imageBuffer[_currentImageIndex].get();
+    if (image->s() != _width ||
+        image->t() != _height)
+    {
+        //OSG_NOTICE<<"WindowCaptureCallback: Allocating image "<<std::endl;
+        image->allocateImage(_width, _height, 1, _pixelFormat, _type);
+
+        if (read_pbo!=0)
+        {
+            //OSG_NOTICE<<"WindowCaptureCallback: deleting pbo "<<read_pbo<<std::endl;
+            ext->glDeleteBuffers (1, &read_pbo);
+            read_pbo = 0;
+        }
+
+        if (copy_pbo!=0)
+        {
+            //OSG_NOTICE<<"WindowCaptureCallback: deleting pbo "<<copy_pbo<<std::endl;
+            ext->glDeleteBuffers (1, &copy_pbo);
+            copy_pbo = 0;
+        }
+    }
+
+
+    bool doCopy = copy_pbo!=0;
+    if (copy_pbo==0)
+    {
+        ext->glGenBuffers(1, &copy_pbo);
+        ext->glBindBuffer(GL_PIXEL_PACK_BUFFER_ARB, copy_pbo);
+        ext->glBufferData(GL_PIXEL_PACK_BUFFER_ARB, image->getTotalSizeInBytes(), 0, GL_STREAM_READ);
+
+        //OSG_NOTICE<<"WindowCaptureCallback: Generating pbo "<<read_pbo<<std::endl;
+    }
+
+    if (read_pbo==0)
+    {
+        ext->glGenBuffers(1, &read_pbo);
+        ext->glBindBuffer(GL_PIXEL_PACK_BUFFER_ARB, read_pbo);
+        ext->glBufferData(GL_PIXEL_PACK_BUFFER_ARB, image->getTotalSizeInBytes(), 0, GL_STREAM_READ);
+
+        //OSG_NOTICE<<"WindowCaptureCallback: Generating pbo "<<read_pbo<<std::endl;
+    }
+    else
+    {
+        ext->glBindBuffer(GL_PIXEL_PACK_BUFFER_ARB, read_pbo);
+    }
+
+    osg::Timer_t tick_start = osg::Timer::instance()->tick();
+
+#if 1
+    glReadPixels(0, 0, _width, _height, _pixelFormat, _type, 0);
+#endif
+
+    osg::Timer_t tick_afterReadPixels = osg::Timer::instance()->tick();
+
+    if (doCopy)
+    {
+
+        ext->glBindBuffer(GL_PIXEL_PACK_BUFFER_ARB, copy_pbo);
+
+        GLubyte* src = (GLubyte*)ext->glMapBuffer(GL_PIXEL_PACK_BUFFER_ARB,
+                                                  GL_READ_ONLY_ARB);
+        if(src)
+        {
+            memcpy(image->data(), src, image->getTotalSizeInBytes());
+            ext->glUnmapBuffer(GL_PIXEL_PACK_BUFFER_ARB);
+        }
+
+        if (_captureOperation.valid())
+        {
+            (*_captureOperation)(*image, _index);
+        }
+    }
+
+    ext->glBindBuffer(GL_PIXEL_PACK_BUFFER_ARB, 0);
+
+    osg::Timer_t tick_afterMemCpy = osg::Timer::instance()->tick();
+
+    updateTimings(tick_start, tick_afterReadPixels, tick_afterMemCpy, tick_afterMemCpy, image->getTotalSizeInBytes());
+
+    _currentImageIndex = nextImageIndex;
+    _currentPboIndex = nextPboIndex;
+}
+
+WindowCaptureCallback::WindowCaptureCallback(int numFrames, Mode mode, FramePosition position, GLenum readBuffer, GLint pixelFormat)
+    : _mode(mode),
+      _position(position),
+      _readBuffer(readBuffer),
+      _numFrames(numFrames),
+      _pixelFormat(pixelFormat)
+{
+}
+
+WindowCaptureCallback::ContextData* WindowCaptureCallback::createContextData(osg::GraphicsContext* gc) const
+{
+    WindowCaptureCallback::ContextData* cd = new WindowCaptureCallback::ContextData(gc, _mode, _readBuffer, _pixelFormat);
+    cd->_captureOperation = _defaultCaptureOperation;
+    return cd;
+}
+
+WindowCaptureCallback::ContextData* WindowCaptureCallback::getContextData(osg::GraphicsContext* gc) const
+{
+    OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
+    osg::ref_ptr<ContextData>& data = _contextDataMap[gc];
+    if (!data) data = createContextData(gc);
+
+    return data.get();
+}
+
+void WindowCaptureCallback::setCaptureOperation(CaptureOperation* operation)
+{
+    _defaultCaptureOperation = operation;
+
+    // Set the capture operation for each ContextData.
+    for (ContextDataMap::iterator it = _contextDataMap.begin(); it != _contextDataMap.end(); ++it)
+    {
+        it->second->_captureOperation = operation;
+    }
+}
+
+
+void WindowCaptureCallback::operator () (osg::RenderInfo& renderInfo) const
+{
+#if !defined(OSG_GLES1_AVAILABLE) && !defined(OSG_GLES2_AVAILABLE)
+    glReadBuffer(_readBuffer);
+#endif
+
+    osg::GraphicsContext* gc = renderInfo.getState()->getGraphicsContext();
+    osg::ref_ptr<ContextData> cd = getContextData(gc);
+    cd->read();
+
+    // If _numFrames is > 0 it means capture that number of frames.
+    if (_numFrames > 0)
+    {
+        --_numFrames;
+        if (_numFrames == 0)
+        {
+            // the callback must remove itself when it's done.
+            if (_position == START_FRAME)
+                renderInfo.getCurrentCamera()->setInitialDrawCallback(0);
+            if (_position == END_FRAME)
+                renderInfo.getCurrentCamera()->setFinalDrawCallback(0);
+        }
+    }
+
+    int prec = osg::notify(osg::INFO).precision(5);
+    OSG_INFO << "WindowCaptureCallback: "
+                           << "copy="      << (cd->_timeForFullCopy*1000.0f)             << "ms, "
+                           << "operation=" << (cd->_timeForCaptureOperation*1000.0f)     << "ms, "
+                           << "total="     << (cd->_timeForFullCopyAndOperation*1000.0f) << std::endl;
+    osg::notify(osg::INFO).precision(prec);
+
+    cd->_timeForFullCopy = 0;
+}
+
+}

--- a/src/WindowCaptureCallback.hpp
+++ b/src/WindowCaptureCallback.hpp
@@ -1,0 +1,118 @@
+#ifndef VIZKIT3D_WINDOW_CAPTURE_CALLBACK
+#define VIZKIT3D_WINDOW_CAPTURE_CALLBACK
+
+#include <osg/Camera>
+#include <vizkit3d/Vizkit3DWidget.hpp>
+
+namespace vizkit3d
+{
+    struct CaptureOperation : public osg::Referenced
+    {
+        virtual ~CaptureOperation() {}
+        virtual void operator()(osg::Image const& image, unsigned int contextID) = 0;
+    };
+
+    /** Draw callback that can be used to capture the render results
+     *
+     * This will usually not be used directly, but used instead through the
+     * corresponding API on Vizkit3dWidget
+     *
+     * This is an almost-pristine copy of the class of the same name that can be
+     * found in the OSG source code. The reason is that this class is kept
+     * private, and the class that exposes this functionality
+     * (ScreenCaptureHandler) does not allow to control the capture mode, thus
+     * using plain old glReadPixels instead of the more modern method of using
+     * PBOs, as well as hardcoding the pixel format to RGB, which (1) is slow on
+     * the OpenGL side (the GPUs use BGR internally) and (2) needs conversion on
+     * the Qt side (which is using BGR as well even if its pixel format is
+     * called RGB ... go figure)
+     */
+    class WindowCaptureCallback : public osg::Camera::DrawCallback
+    {
+    public:
+        typedef Vizkit3DWidget::GrabbingMode Mode;
+
+        enum FramePosition
+        {
+            START_FRAME,
+            END_FRAME
+        };
+
+        WindowCaptureCallback(int numFrames, Mode mode, FramePosition position, GLenum readBuffer, GLint pixelFormat);
+
+        FramePosition getFramePosition() const { return _position; }
+
+        void setCaptureOperation(CaptureOperation* operation);
+        CaptureOperation* getCaptureOperation() { return _contextDataMap.begin()->second->_captureOperation.get(); }
+
+        void setFramesToCapture(int numFrames) { _numFrames = numFrames; }
+        int getFramesToCapture() const { return _numFrames; }
+
+        virtual void operator () (osg::RenderInfo& renderInfo) const;
+
+        struct ContextData : public osg::Referenced
+        {
+            ContextData(osg::GraphicsContext* gc, Mode mode, GLenum readBuffer, GLint pixelFormat);
+
+            void getSize(osg::GraphicsContext* gc, int& width, int& height);
+
+            void updateTimings(osg::Timer_t tick_start,
+                    osg::Timer_t tick_afterReadPixels,
+                    osg::Timer_t tick_afterMemCpy,
+                    osg::Timer_t tick_afterCaptureOperation,
+                    unsigned int dataSize);
+
+            void read();
+            void readPixels();
+            void singlePBO(osg::GLBufferObject::Extensions* ext);
+            void multiPBO(osg::GLBufferObject::Extensions* ext);
+
+            typedef std::vector< osg::ref_ptr<osg::Image> >             ImageBuffer;
+            typedef std::vector< GLuint > PBOBuffer;
+
+            osg::GraphicsContext*   _gc;
+            unsigned int            _index;
+            Mode                    _mode;
+            GLenum                  _readBuffer;
+
+            GLenum                  _pixelFormat;
+            GLenum                  _type;
+            int                     _width;
+            int                     _height;
+
+            unsigned int            _currentImageIndex;
+            ImageBuffer             _imageBuffer;
+
+            unsigned int            _currentPboIndex;
+            PBOBuffer               _pboBuffer;
+
+            unsigned int            _reportTimingFrequency;
+            unsigned int            _numTimeValuesRecorded;
+            double                  _timeForReadPixels;
+            double                  _timeForMemCpy;
+            double                  _timeForCaptureOperation;
+            double                  _timeForFullCopy;
+            double                  _timeForFullCopyAndOperation;
+            osg::Timer_t            _previousFrameTick;
+
+            osg::ref_ptr<CaptureOperation> _captureOperation;
+        };
+
+        typedef std::map<osg::GraphicsContext*, osg::ref_ptr<ContextData> > ContextDataMap;
+
+        ContextData* createContextData(osg::GraphicsContext* gc) const;
+        ContextData* getContextData(osg::GraphicsContext* gc) const;
+
+        Mode                        _mode;
+        FramePosition               _position;
+        GLenum                      _readBuffer;
+        mutable OpenThreads::Mutex  _mutex;
+        mutable ContextDataMap      _contextDataMap;
+        mutable int                 _numFrames;
+        GLint                       _pixelFormat;
+
+        osg::ref_ptr<CaptureOperation> _defaultCaptureOperation;
+    };
+}
+
+#endif


### PR DESCRIPTION
This set of commits contains two attempts at improving the grabbing implementation. The main reason was to fix a crash related to the direct use of glReadPixels, and to use the "good" OSG method of using a drawcallback instead of having an implicit assumption about the synchronization between OSG/OpenGL and the caller.

The first attempt used ScreenCaptureOperation. It works, but some parameters were hardcoded (the problematic one being the pixelFormat), which made the whole thing pretty slow (drivers are optimized to handle BGR/BGRA, which is also Qt's image format, while ScreenCaptureOperation was hardcoded to RGB).

The second attempt copied OSG's WindowCaptureCallback (which is a private class in OSG) and used it almost as-is. Interestingly, it will allow streaming implementations (e.g. save video) to be faster than the glReadPixels one (the glReadPixels being asynchronous, multi-buffering allows to not wait for the GPU's DMA engine to copy data before starting to render the next frame)