### PR TITLE
Allow to export currently displayed scene to osg scene file

### DIFF
--- a/src/Vizkit3DWidget.hpp
+++ b/src/Vizkit3DWidget.hpp
@@ -330,6 +330,13 @@ namespace vizkit3d
              */
             void clearEnvironmentPlugin();
 
+            /** Exports current scene to OSG scene file
+             *
+             * Opens file dialog and saves currently displayed scene to a
+             * OSG scene file.
+             */
+            void exportScene();
+
         signals:
             void addPlugins(QObject* plugin,QObject* parent);
             void removePlugins(QObject* plugin);


### PR DESCRIPTION
Adds push button below QPropertyBrowserWidget that opens a file dialog to select a file to store scene to.