### PR TITLE
Add ability to offload tasks into a secondary thread while the gui re…

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -12,5 +12,6 @@
     <depend package="qt4-opengl" />
     <depend package="boost" />
     <depend package="base/cmake" />
+    <depend package="tools/orocos" />
     <!--    <depend package="qt-designer" /> !-->
 </package>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ rock_library(vizkit3d
         CoordinateFrame.cpp
         DefaultManipulator.cpp
         EnableGLDebugOperation.cpp
+	TaskWorker.hpp
         ${PROPERTY_BROWSER_RESOURCES} 
     MOC
         Vizkit3DPlugin.cpp 
@@ -40,6 +41,7 @@ rock_library(vizkit3d
         AxesNode.hpp
         OsgVisitors.hpp
         QtThreadedWidget.hpp
+	TaskWorker.hpp
         Vizkit3DBase.hpp
         Vizkit3DPlugin.hpp
         Vizkit3DWidget.hpp
@@ -52,7 +54,7 @@ rock_library(vizkit3d
         ${HEADERS_EXTRA}
     LIBS ${Boost_THREAD_LIBRARY} ${Boost_SYSTEM_LIBRARY}
     DEPS_CMAKE OpenGL
-    DEPS_PKGCONFIG openscenegraph openscenegraph-osgQt ${DEPS_EXTRA})
+    DEPS_PKGCONFIG openscenegraph openscenegraph-osgQt orocos_cpp ${DEPS_EXTRA})
 
 rock_library(vizkitwidgetloader
     MOC QVizkitWidgetLoader.cpp

--- a/src/TaskWorker.hpp
+++ b/src/TaskWorker.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <rtt/transports/corba/TaskContextServer.hpp>
+
+#include <atomic>
+#include <stdexcept>
+#include <QMap>
+#include <iterator>
+
+#include <QObject>
+#include <QBasicTimer>
+
+class QTimerEvent;
+class QBasicTimer;
+
+class SignalSlotProvider : public QObject
+{
+    Q_OBJECT
+
+public:
+    SignalSlotProvider(QObject *parent = 0)
+        : QObject(parent)
+        , m_cancelled(false)
+        , m_readInterval(100)
+        , m_timer(new QBasicTimer)
+    {
+    }
+
+public slots:
+    void setReadInterval(unsigned int interval = 100)
+    {
+        m_readInterval = interval;
+        if (m_timer->isActive()) {
+            m_timer->stop();
+            m_timer->start(m_readInterval, this);
+        }
+    }
+
+    unsigned int getReadInterval()
+    {
+        return m_readInterval;
+    }
+
+    void start()
+    {
+        readInput();
+        m_timer->start(m_readInterval, this);
+    }
+
+    void stop()
+    {
+        m_timer->stop();
+    }
+
+signals:
+    void valueChanged(const QString &value);
+    void dataAvailable();
+
+protected:
+    void timerEvent(QTimerEvent *)
+    {
+        readInput();
+    }
+
+    virtual void readInput() = 0;
+
+private:
+    std::atomic<bool> m_cancelled;
+    unsigned int m_readInterval;
+    QBasicTimer* m_timer;
+};
+
+
+template <typename T>
+class TaskWorker : public SignalSlotProvider {
+public:
+    TaskWorker<T>(QObject* parent = 0)
+        : SignalSlotProvider(parent)
+        , m_reader(nullptr)
+    {
+    }
+
+    void setReader(RTT::InputPort<T>* reader)
+    {
+        m_reader = reader;
+    }
+
+    void addObserver(const QString& name, std::function<void (T)> observer)
+    {
+        m_observers.insert(name, observer);
+    }
+
+    void removeObserver(const QString& name)
+    {
+        if (m_observers.has(name))
+            m_observers.remove(name);
+    }
+
+    void removeObserver(std::function<void (T)> observer)
+    {
+        typename QMap<QString, std::function<void (T)> >::iterator iter;
+        for (iter = m_observers.begin(); iter != m_observers.end(); ++iter) {
+            if ((*iter).value() == observer)
+                m_observers.remove((*iter).key());
+        }
+    }
+
+protected:
+    void virtual readInput()
+    {
+        T data;
+        while(!m_observers.empty() && m_reader->read(data, false) == RTT::NewData) {
+            for (auto f : m_observers)
+                f(data);
+            emit dataAvailable();
+        }
+    }
+
+private:
+    RTT::InputPort<T>* m_reader;
+    QMap<QString, std::function<void (T)>> m_observers;
+};


### PR DESCRIPTION
Currently the common way to run a Qt gui to visualize a task is to move the gui into a secondary thread using **QThreadedWidget**. This usually leads to a warning in the console stating that _"QApplication was not created in main() thread"_. The Qt documentation provides the following clarification in this regard (see http://doc.qt.io/qt-5/thread-basics.html):

> As mentioned, each program has one thread when it is started. This thread is called the "main thread" (also known as the "GUI thread" in Qt applications). The Qt GUI must run in this thread. All widgets and several related classes, for example QPixmap, don't work in secondary threads. A secondary thread is commonly referred to as a "worker thread" because it is used to offload processing work from the main thread.

It would therefore be helpful to have a way to reverse the current idiom which offloads the gui part into the secondary thread while keeping the task loop (where we read from a port) inside the main thread. Just as with QThreadedWidget, the required boilerplate code should be kept to a minimum. This would be feasible if we could have a QObject derviative worker object running in a separate thread and notifiying us -- using a signal -- whenever new data arrives. In order to avoid repetitive boilerplate code the worker class should be **generic over the data type** received by the input port.

Unfortunately this is not possible as QObject (or rather any QObject derivate which declares Q_OBJECT) doesn't support template paratemers. The following article however provides some ideas to work around this issue: https://doc.qt.io/archives/qq/qq15-academic.html. 

This pull request provides an implementation of the mentioned ideas. It uses signals to notify the consumer about incoming data, but unfortunately can't pass the data along with the signal due to the constraints outlined above, so the data needs to be fetched separately. The code neccessary to store and fetch the incoming information is not yet provided however and thus would need to be implemented in a subclass (by means of overriding the **virtual method** `readInput`). The current approach instead incorporates the **observer pattern**. We register a set of lambda functions as _observers_ that will subsequently be called whenever new data arrives. The new data is then passed on as a _parameter_ to the callback.

The following examples shows how the class can be utilized in a scenario, where we receive data from a task called "top" about the processes currently running on a system:

```
// spawn a given task: in this example a task that lists processes
spawner.spawnTask("top::Task", "top");
spawner.waitUntilAllReady(base::Time::fromSeconds(2.0));
top::proxies::Task top("top");
top.configure();
top.start();

// here we instantiate the thread and the worker, pass the input reader
// to the worker and move the worker into the secondary worker thread
auto workerThread = new QThread();
auto t = std::unique_ptr<QThread>(workerThread);
auto worker = new TaskWorker<robotop::SystemStatus>;
worker->addObserver("observer1", [&](robotop::SystemStatus systemStatus) {
    widget->updateModel(systemStatus);
});
worker->setReader(&top.systemStatus.getReader());
worker->setReadInterval(1000);
worker->moveToThread(workerThread);

// then we connect some signals and slots and start the worker thread
QObject::connect(workerThread, SIGNAL(finished()), worker, SLOT(deleteLater()));
QObject::connect(qApp, SIGNAL(lastWindowClosed()), worker, SLOT(stop()));
QTimer::singleShot(1000, worker, SLOT(start()));
workerThread->start();

// now we can show the widget and start the Qt event loop
widget->show();
app.exec();
```

This approach is more in line with the way Qt is supposed to be used and should replace the QThreadedWidget approach.

Sorry for the rather lengthy explanation.
