### PR TITLE
Render transformer graph labels in Screen coordinates

### DIFF
--- a/src/TransformerGraph.cpp
+++ b/src/TransformerGraph.cpp
@@ -35,7 +35,7 @@ osg::PositionAttitudeTransform *getTransform(osg::Node *node,bool raise=true)
     return pos;
 }
 
-osg::PositionAttitudeTransform *createFrame(const std::string &name,bool root=false,float textSize=0.1)
+osg::PositionAttitudeTransform *createFrame(const std::string &name,bool root=false,float textSize=20)
 {
     osg::PositionAttitudeTransform* node = new osg::PositionAttitudeTransform();
     node->setName(name.c_str());
@@ -51,11 +51,21 @@ osg::PositionAttitudeTransform *createFrame(const std::string &name,bool root=fa
     osg::Geode *text_geode = new osg::Geode;
     osgText::Text *text= new osgText::Text;
     text->setText(name);
-    text->setCharacterSize(textSize);
-    if(root)
-        text->setPosition(osg::Vec3d(textSize/2,-textSize*1.5,0));
-    else
-        text->setPosition(osg::Vec3d(textSize/2,textSize/2,0));
+
+    text->setCharacterSize(textSize);    
+    osg::StateSet *set = text_geode->getOrCreateStateSet();
+    set->setMode(GL_DEPTH_TEST, osg::StateAttribute::OFF); // Disable depth test to avoid sort problems and Lighting
+    set->setMode(GL_LIGHTING, osg::StateAttribute::OFF);
+    osgText::Font* font = osgText::Font::getDefaultFont();
+    font->setMinFilterHint(osg::Texture::NEAREST); // aliasing when zoom out, this doesnt look so ugly because text is small
+    font->setMagFilterHint(osg::Texture::NEAREST); // aliasing when zoom in
+    text->setFont(font);    
+    text->setAxisAlignment(osgText::Text::SCREEN);
+    text->setCharacterSizeMode(osgText::Text::SCREEN_COORDS);
+    text->setDrawMode(osgText::Text::TEXT | osgText::Text::ALIGNMENT);
+    text->setAlignment(osgText::Text::CENTER_TOP);
+    text->setBackdropType(osgText::Text::OUTLINE);
+    text->setBackdropColor(osg::Vec4(0, 0, 0, 1.0f));
     text_geode->addDrawable(text);
     switch_node->addChild(text_geode,true);
 
@@ -257,7 +267,6 @@ class TextSizeSetter: public ::osg::NodeVisitor
             
             osgText::Text* text = getFrameText(trans);
             text->setCharacterSize(size);
-            text->setPosition(osg::Vec3d(size / 2, size / 2, size / 2));
 
             traverse(node);
         }
@@ -349,7 +358,7 @@ class DescriptionVisitor: public ::osg::NodeVisitor
 
 osg::Node *TransformerGraph::create(const std::string &name)
 {
-    return createFrame(name,true,0.1);
+    return createFrame(name,true);
 }
 
 TransformerGraph::GraphDescription TransformerGraph::getGraphDescription(osg::Node& transformer)


### PR DESCRIPTION
This improves readability of the transformer frame names by rendering them in screen coordinates and setting a reasonable character size