### PR TITLE
Fix pluginmap nullptr access

### DIFF
--- a/src/QPropertyBrowserWidget.cpp
+++ b/src/QPropertyBrowserWidget.cpp
@@ -140,12 +140,12 @@ void QPropertyBrowserWidget::addProperties(QObject* obj,QObject* parent)
     }
     
     // connect plugin signal, to notice if a property has changed
-    if (!this->connect(obj, SIGNAL(propertyChanged(QString)), this, SLOT(propertyChangedInObject(QString))))
+    if (!this->connect(obj, SIGNAL(propertyChanged(QString)), SLOT(propertyChangedInObject(QString))))
     {
         std::cerr << "The QObject has no SIGNAL 'propertyChanged(QString)', the property browser widget won't get updated "
                   << "if properties in the QObject will change." << std::endl;
     }
-    this->connect(obj, SIGNAL(destroyed(QObject*)), this, SLOT(propObjDestroyed(QObject*)));
+    this->connect(obj, SIGNAL(destroyed(QObject*)), SLOT(propObjDestroyed(QObject*)));
 }
 
 void QPropertyBrowserWidget::propObjDestroyed(QObject *delObj) {
@@ -159,7 +159,7 @@ void QPropertyBrowserWidget::propObjDestroyed(QObject *delObj) {
 void QPropertyBrowserWidget::removeProperties(QObject* obj)
 {
     // disconnect signal
-    this->disconnect(obj, SIGNAL(propertyChanged(QString)), this, SLOT(propertyChangedInObject(QString)));
+    disconnect(obj, 0, this, 0);
     
     // remove properties
     if(objectToGroup[obj])

--- a/src/QPropertyBrowserWidget.cpp
+++ b/src/QPropertyBrowserWidget.cpp
@@ -117,6 +117,12 @@ void QPropertyBrowserWidget::addProperties(QObject* obj,QObject* parent)
     QHash<QString, QtProperty*>* groupMap = new QHash<QString, QtProperty*>();
     for(QList<QtVariantProperty*>::const_iterator it = properties.begin(); it != properties.end(); it++)
     {
+        std::cout << "adding to map: " << (*it)->propertyName().toStdString() << " -> " << obj << std::endl;
+        QHash<QtProperty*, QObject*>::const_iterator i = propertyToObject.find(*it);
+        if (i != propertyToObject.end()) {
+            std::cerr << "property already present!" << std::endl;
+            continue;
+        }
         group->addSubProperty(*it);
         propertyToObject[*it] = obj;
         (*groupMap)[(*it)->propertyName()] = *it;
@@ -139,6 +145,12 @@ void QPropertyBrowserWidget::addProperties(QObject* obj,QObject* parent)
         std::cerr << "The QObject has no SIGNAL 'propertyChanged(QString)', the property browser widget won't get updated "
                   << "if properties in the QObject will change." << std::endl;
     }
+    this->connect(obj, SIGNAL(destroyed(QObject*)), this, SLOT(propObjDestroyed(QObject*)));
+}
+
+void QPropertyBrowserWidget::propObjDestroyed(QObject *delObj) {
+    std::cout << "Object destroyed: " << delObj << std::endl;
+    removeProperties(delObj);
 }
 
 /**
@@ -155,9 +167,14 @@ void QPropertyBrowserWidget::removeProperties(QObject* obj)
         QList<QtProperty*> properties = objectToGroup[obj]->subProperties();
         for(QList<QtProperty*>::iterator it = properties.begin(); it != properties.end(); it++)
         {
-            propertyToObject.remove(*it); 
+            propertyToObject.remove(*it);
+            objectToGroup[obj]->removeSubProperty(*it);
         }
         this->removeProperty(objectToGroup[obj]);
+        if(objectToGroup[obj]->subProperties().size() == 0) {
+            std::cout << "No more properties in group: " << obj << std::endl;
+            delete objectToGroup[obj];
+        }
         objectToGroup.remove(obj);
     }
     // delete property group hash map
@@ -174,19 +191,24 @@ void QPropertyBrowserWidget::removeProperties(QObject* obj)
  */
 void QPropertyBrowserWidget::propertyChangedInGUI(QtProperty* property, const QVariant& val)
 {
-    if (propertyToObject[property] != 0)
+    QHash<QtProperty*, QObject*>::const_iterator i = propertyToObject.find(property);
+    
+    if (i == propertyToObject.end())
+        return;
+    
+    std::cout << "accessing from map: " << property->propertyName().toStdString() << " -> " << i.value() << std::endl;
+    
+    QtVariantProperty* prop = dynamic_cast<QtVariantProperty*>(property);
+    if(prop && prop->propertyType() == QtVariantPropertyManager::enumTypeId())
     {
-
-        QtVariantProperty* prop = dynamic_cast<QtVariantProperty*>(property);
-        if(prop && prop->propertyType() == QtVariantPropertyManager::enumTypeId())
-        {
-            // emulate string list by using enums
-            QStringList list;
-            list << prop->attributeValue("enumNames").toStringList().at(val.toInt());
-            propertyToObject[property]->setProperty(property->propertyName().toStdString().c_str(), QVariant(list));
-        }
-        else
-            propertyToObject[property]->setProperty(property->propertyName().toStdString().c_str(), val);
+        // emulate string list by using enums
+        QStringList list;
+        list << prop->attributeValue("enumNames").toStringList().at(val.toInt());
+        i.value()->setProperty(property->propertyName().toStdString().c_str(), QVariant(list));
+    }
+    else
+    {
+        i.value()->setProperty(property->propertyName().toStdString().c_str(), val);
     }
 }
 

--- a/src/QPropertyBrowserWidget.cpp
+++ b/src/QPropertyBrowserWidget.cpp
@@ -241,8 +241,11 @@ void QPropertyBrowserWidget::propertyChangedInObject(QString property_name)
 
             if (value.type() == QVariant::StringList)
                 dynamic_cast<QtVariantProperty*>(property)->setAttribute("enumNames", value);
-            else
+            else {
+                variantManager->blockSignals(true);
                 variantManager->setValue(property, value);
+                variantManager->blockSignals(false);
+            }
         }
     }
 }
@@ -266,7 +269,9 @@ void QPropertyBrowserWidget::propertyChangedInObject()
             QtProperty* property = groupMap->value(property_name);
             if(property)
             {
+                variantManager->blockSignals(true);
                 variantManager->setValue(property, metaObj->property(i).read(obj));
+                variantManager->blockSignals(false);
             }
         }
     }

--- a/src/QPropertyBrowserWidget.cpp
+++ b/src/QPropertyBrowserWidget.cpp
@@ -117,7 +117,7 @@ void QPropertyBrowserWidget::addProperties(QObject* obj,QObject* parent)
     QHash<QString, QtProperty*>* groupMap = new QHash<QString, QtProperty*>();
     for(QList<QtVariantProperty*>::const_iterator it = properties.begin(); it != properties.end(); it++)
     {
-        std::cout << "adding to map: " << (*it)->propertyName().toStdString() << " -> " << obj << std::endl;
+        //std::cout << "adding to map: " << (*it)->propertyName().toStdString() << " -> " << obj << std::endl;
         QHash<QtProperty*, QObject*>::const_iterator i = propertyToObject.find(*it);
         if (i != propertyToObject.end()) {
             std::cerr << "property already present!" << std::endl;
@@ -149,7 +149,7 @@ void QPropertyBrowserWidget::addProperties(QObject* obj,QObject* parent)
 }
 
 void QPropertyBrowserWidget::propObjDestroyed(QObject *delObj) {
-    std::cout << "Object destroyed: " << delObj << std::endl;
+    //std::cout << "Object destroyed: " << delObj << std::endl;
     removeProperties(delObj);
 }
 
@@ -172,7 +172,7 @@ void QPropertyBrowserWidget::removeProperties(QObject* obj)
         }
         this->removeProperty(objectToGroup[obj]);
         if(objectToGroup[obj]->subProperties().size() == 0) {
-            std::cout << "No more properties in group: " << obj << std::endl;
+            //std::cout << "No more properties in group: " << obj << std::endl;
             delete objectToGroup[obj];
         }
         objectToGroup.remove(obj);
@@ -196,7 +196,7 @@ void QPropertyBrowserWidget::propertyChangedInGUI(QtProperty* property, const QV
     if (i == propertyToObject.end())
         return;
     
-    std::cout << "accessing from map: " << property->propertyName().toStdString() << " -> " << i.value() << std::endl;
+    //std::cout << "accessing from map: " << property->propertyName().toStdString() << " -> " << i.value() << std::endl;
     
     QtVariantProperty* prop = dynamic_cast<QtVariantProperty*>(property);
     if(prop && prop->propertyType() == QtVariantPropertyManager::enumTypeId())

--- a/src/QPropertyBrowserWidget.hpp
+++ b/src/QPropertyBrowserWidget.hpp
@@ -24,6 +24,7 @@ protected slots:
     void propertyChangedInGUI(QtProperty *property, const QVariant &val);
     void propertyChangedInObject(QString property_name);
     void propertyChangedInObject();
+    void propObjDestroyed(QObject*);
     
 private:
     QHash<QtProperty*, QObject*> propertyToObject;

--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -745,7 +745,9 @@ void Vizkit3DWidget::addPluginIntern(QObject* plugin,QObject *parent)
     
     if (has_plugin) {
         //std::cerr << viz_plugin->getPluginName().toStdString() <<": plugin already present!" << std::endl;
-    } else if (viz_plugin) {
+        removePlugin(plugin);
+    } 
+    if (viz_plugin) {
         viz_plugin->setParent(this);
         viz_plugin->setVisualizationFrame(getRootNode()->getName().c_str());
 

--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -481,7 +481,7 @@ void Vizkit3DWidget::registerDataHandler(VizPluginBase* viz)
 {
     osg::Group* initial_parent = TransformerGraph::getFrameGroup(*getRootNode());
     assert(initial_parent);
-    plugins.insert(make_pair(QPointer<VizPluginBase>(viz), initial_parent));
+    plugins.insert(make_pair(viz, VizPluginInfo(viz, initial_parent)));
 }
 
 void Vizkit3DWidget::deregisterDataHandler(VizPluginBase* viz)
@@ -504,14 +504,14 @@ void Vizkit3DWidget::enableDataHandler(VizPluginBase *viz)
 
     PluginMap::iterator it = plugins.find(viz);
     if (it != plugins.end())
-        it->second->addChild(viz->getRootNode());
+        (it->second).osg_group_ptr->addChild(viz->getRootNode());
 }
 
 void Vizkit3DWidget::disableDataHandler(VizPluginBase *viz)
 {
     PluginMap::iterator it = plugins.find(viz);
     if (it != plugins.end())
-        it->second->removeChild( viz->getRootNode() );
+        (it->second).osg_group_ptr->removeChild( viz->getRootNode() );
 }
 
 void Vizkit3DWidget::setPluginEnabled(QObject* plugin, bool enabled)
@@ -532,7 +532,7 @@ void Vizkit3DWidget::setPluginEnabled(QObject* plugin, bool enabled)
 
     // Check the current state
     osg::Node::ParentList const& list = viz_plugin->getRootNode()->getParents();
-    bool is_enabled = std::find(list.begin(), list.end(), plugin_it->second) != list.end();
+    bool is_enabled = std::find(list.begin(), list.end(), (plugin_it->second).osg_group_ptr) != list.end();
 
     if (enabled && !is_enabled)
         enableDataHandler(viz_plugin);
@@ -547,23 +547,23 @@ void Vizkit3DWidget::pluginActivityChanged(bool enabled)
 
 void Vizkit3DWidget::setEnvironmentPlugin(QObject* plugin)
 {
-    EnvPluginBase* env_plugin = dynamic_cast<EnvPluginBase*>(plugin);
-    if (!env_plugin)
+    EnvPluginBase* env_plugin_new = dynamic_cast<EnvPluginBase*>(plugin);
+    if (!env_plugin_new)
         throw std::invalid_argument("plugin given to setEnvironmentPlugin is not from a subclass of EnvPluginBase");
 
-    PluginMap::iterator it = plugins.find(env_plugin);
+    PluginMap::iterator it = plugins.find(env_plugin_new);
     if (it == plugins.end())
     {
-        addPlugin(env_plugin);
-        it = plugins.find(env_plugin);
+        addPlugin(env_plugin_new);
+        it = plugins.find(env_plugin_new);
     }
 
     clearEnvironmentPlugin();
 
-    it->second->removeChild(env_plugin->getRootNode());
-    env_plugin->getRefNode()->addChild(root);
-    this->env_plugin = env_plugin;
-    setEnvironmentPluginEnabled(env_plugin->isPluginEnabled());
+    (it->second).osg_group_ptr->removeChild(env_plugin_new->getRootNode());
+    env_plugin_new->getRefNode()->addChild(root);
+    this->env_plugin = env_plugin_new;
+    setEnvironmentPluginEnabled(env_plugin_new->isPluginEnabled());
 }
 
 void Vizkit3DWidget::setEnvironmentPluginEnabled(bool enabled)
@@ -596,7 +596,7 @@ void Vizkit3DWidget::clearEnvironmentPlugin()
     env_plugin->getRefNode()->removeChild(root);
     PluginMap::iterator it = plugins.find(env_plugin);
     if (it != plugins.end())
-        it->second->addChild(env_plugin->getRootNode());
+        (it->second).osg_group_ptr->addChild(env_plugin->getRootNode());
 }
 
 void Vizkit3DWidget::setCameraLookAt(double x, double y, double z)
@@ -777,6 +777,7 @@ void Vizkit3DWidget::pluginChildrenChanged()
  */
 void Vizkit3DWidget::removePluginIntern(QObject* plugin)
 {
+    std::cout << __FUNCTION__ << " removing " << plugin << " (thread " << QThread::currentThreadId() << ")" << std::endl;
     vizkit3d::VizPluginBase* viz_plugin = dynamic_cast<vizkit3d::VizPluginBase*>(plugin);
     if (viz_plugin)
     {
@@ -825,14 +826,13 @@ void Vizkit3DWidget::setPluginDataFrameIntern(const QString& frame, QObject* plu
     PluginMap::iterator it = plugins.find(viz);
     if (it != plugins.end())
     {
+        (it->second).osg_group_ptr = node;
+        
         if(viz != env_plugin && viz->isPluginEnabled())
         {
             disableDataHandler(viz);
-            it->second = node;
             enableDataHandler(viz);
         }
-        else
-            it->second = node;
     }
 }
 
@@ -888,12 +888,12 @@ void Vizkit3DWidget::setTransformation(const QString &source_frame,const QString
         
         PluginMap::iterator it = plugins.begin();
         for(;it != plugins.end();++it) {
-            std::cout << __FUNCTION__ << " update call for plugin at address " << it->first << std::endl;
-            if (it->first != 0) {
-                std::cout << __FUNCTION__ << " update call for plugin named " << it->first->getPluginName().toStdString() << std::endl;
-                it->first->setVisualizationFrame(it->first->getVisualizationFrame());
+            std::cout << __FUNCTION__ << " update call for plugin at address " << it->first << " (thread " << QThread::currentThreadId() << ")" <<  std::endl;
+            if ((it->second).weak_ptr.data()) {
+                std::cout << __FUNCTION__ << " update call for plugin named " << (it->second).weak_ptr.data()->getPluginName().toStdString() << " (thread " << QThread::currentThreadId() << ")" <<  std::endl;
+                (it->second).weak_ptr.data()->setVisualizationFrame((it->second).weak_ptr.data()->getVisualizationFrame());
             } else {
-                std::cout << __FUNCTION__ << " ptr to plugin is 0 " << std::endl;
+                std::cout << __FUNCTION__ << " ptr to plugin is 0 " << " (thread " << QThread::currentThreadId() << ")" <<  std::endl;
             }
         }
     }
@@ -1028,7 +1028,7 @@ QObject* Vizkit3DWidget::loadLib(QString file_path)
 QStringList* Vizkit3DWidget::getAvailablePlugins()
 {
     // qt ruby is crashing if not a pointer is returned
-    QStringList *plugins = new QStringList;
+    QStringList *plugins_str_list = new QStringList;
 
     QStringList name_filters;
     name_filters << "lib*-viz.so" << "lib*-viz.dylib" << "lib*-viz.dll";
@@ -1056,7 +1056,7 @@ QStringList* Vizkit3DWidget::getAvailablePlugins()
                 QStringList* lib_plugins  = factory->getAvailablePlugins();
                 QStringList::iterator iter3 = lib_plugins->begin();
                 for(;iter3 != lib_plugins->end();++iter3)
-                    *plugins << QString(*iter3 + "@" + file_info.absoluteFilePath());
+                    *plugins_str_list << QString(*iter3 + "@" + file_info.absoluteFilePath());
             }
             catch(std::runtime_error e)
             {
@@ -1064,7 +1064,7 @@ QStringList* Vizkit3DWidget::getAvailablePlugins()
             }
         }
     }
-    return plugins;
+    return plugins_str_list;
 }
 
 QObject* Vizkit3DWidget::loadPlugin(QString lib_name,QString plugin_name)

--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -744,8 +744,7 @@ void Vizkit3DWidget::addPluginIntern(QObject* plugin,QObject *parent)
     bool has_plugin = plugins.find(viz_plugin) != plugins.end();
     
     if (has_plugin) {
-        std::cerr << viz_plugin->getPluginName().toStdString() <<": plugin already present!" << std::endl;
-        //removePlugin(plugin);
+        //std::cerr << viz_plugin->getPluginName().toStdString() <<": plugin already present!" << std::endl;
     } else if (viz_plugin) {
         viz_plugin->setParent(this);
         viz_plugin->setVisualizationFrame(getRootNode()->getName().c_str());
@@ -777,7 +776,7 @@ void Vizkit3DWidget::pluginChildrenChanged()
  */
 void Vizkit3DWidget::removePluginIntern(QObject* plugin)
 {
-    std::cout << __FUNCTION__ << " removing " << plugin << " (thread " << QThread::currentThreadId() << ")" << std::endl;
+    //std::cout << __FUNCTION__ << " removing " << plugin << " (thread " << QThread::currentThreadId() << ")" << std::endl;
     vizkit3d::VizPluginBase* viz_plugin = dynamic_cast<vizkit3d::VizPluginBase*>(plugin);
     if (viz_plugin)
     {
@@ -888,12 +887,12 @@ void Vizkit3DWidget::setTransformation(const QString &source_frame,const QString
         
         PluginMap::iterator it = plugins.begin();
         for(;it != plugins.end();++it) {
-            std::cout << __FUNCTION__ << " update call for plugin at address " << it->first << " (thread " << QThread::currentThreadId() << ")" <<  std::endl;
+            //std::cout << __FUNCTION__ << " update call for plugin at address " << it->first << " (thread " << QThread::currentThreadId() << ")" <<  std::endl;
             if ((it->second).weak_ptr.data()) {
-                std::cout << __FUNCTION__ << " update call for plugin named " << (it->second).weak_ptr.data()->getPluginName().toStdString() << " (thread " << QThread::currentThreadId() << ")" <<  std::endl;
+                //std::cout << __FUNCTION__ << " update call for plugin named " << (it->second).weak_ptr.data()->getPluginName().toStdString() << " (thread " << QThread::currentThreadId() << ")" <<  std::endl;
                 (it->second).weak_ptr.data()->setVisualizationFrame((it->second).weak_ptr.data()->getVisualizationFrame());
             } else {
-                std::cout << __FUNCTION__ << " ptr to plugin is 0 " << " (thread " << QThread::currentThreadId() << ")" <<  std::endl;
+                //std::cout << __FUNCTION__ << " ptr to plugin is 0 " << " (thread " << QThread::currentThreadId() << ")" <<  std::endl;
             }
         }
     }

--- a/src/Vizkit3DWidget.hpp
+++ b/src/Vizkit3DWidget.hpp
@@ -405,7 +405,7 @@ namespace vizkit3d
             /** The set of known plugins, as a mapping from the plugin to the osg::Node
              * to which it should be attached.
              */
-            typedef std::map<VizPluginBase*, osg::ref_ptr<osg::Group> > PluginMap;
+            typedef std::map<QPointer<VizPluginBase>, osg::ref_ptr<osg::Group> > PluginMap;
             PluginMap plugins;
 
             QTimer _timer;

--- a/src/Vizkit3DWidget.hpp
+++ b/src/Vizkit3DWidget.hpp
@@ -405,7 +405,17 @@ namespace vizkit3d
             /** The set of known plugins, as a mapping from the plugin to the osg::Node
              * to which it should be attached.
              */
-            typedef std::map<QPointer<VizPluginBase>, osg::ref_ptr<osg::Group> > PluginMap;
+            struct VizPluginInfo {
+                osg::ref_ptr<osg::Group> osg_group_ptr;
+                QWeakPointer<VizPluginBase> weak_ptr;
+                
+                VizPluginInfo(VizPluginBase* plugin_ptr_, osg::ref_ptr<osg::Group> osg_group_ptr_)
+                  : osg_group_ptr(osg_group_ptr_),
+                    weak_ptr(plugin_ptr_) 
+                {
+                }
+            };
+            typedef std::map<VizPluginBase*,  VizPluginInfo> PluginMap;
             PluginMap plugins;
 
             QTimer _timer;


### PR DESCRIPTION
For one setup, some plugins are added and removed when starting vizkit3dwidget. However, waiting for the destroyed signal is not a safe way to handle this, as other pending signals can be handled first. The plugins map still contains the pointers to the destroyed objects in this case and thus a segfault occurs. 
In general it is not a good idea to store (normal) pointers to objects if it cannot be made sure the object will not be destroyed. 
In this fix I try to keep the map functionality with the normal (maybe dangling) pointer, but also store a QWeakPointer to allow checking it the object still exists. Also includes #37 .