### PR TITLE
fix osgviz root node

### DIFF
--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -247,7 +247,7 @@ Vizkit3DWidget::Vizkit3DWidget(QWidget* parent,const QString &world_name,bool au
 
     // create root scene node
     root = createSceneGraph(world_name);
-    window->addChild(root);
+    osgviz->getRootNode()->addChild(root);
 
     // create osg widget
     QWidget* widget = graphicsWindowQt->getGLWidget();


### PR DESCRIPTION
Attaching to osgviz window root is intended for single window scenes/objects
(e.g. HUDs) The 3D Scene should be gobal across multiple windows and
views.