### PR TITLE
add a default camera position on startup

### DIFF
--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -282,6 +282,11 @@ Vizkit3DWidget::Vizkit3DWidget(QWidget* parent,const QString &world_name,bool au
     camera->setCullMask(~INVISIBLE_NODE_MASK);
     camera->setComputeNearFarMode(osg::CullSettings::DO_NOT_COMPUTE_NEAR_FAR);
 
+    osg::Vec3 lookAtPos(0,0,0);
+    osg::Vec3 eyePos(-4,-4,4);
+    osg::Vec3 upVector(0,0,1);
+    changeCameraView(&lookAtPos, &eyePos, &upVector);
+
     //connect signals and slots
     connect(this, SIGNAL(addPlugins(QObject*,QObject*)), this, SLOT(addPluginIntern(QObject*,QObject*)));
     connect(this, SIGNAL(removePlugins(QObject*)), this, SLOT(removePluginIntern(QObject*)));


### PR DESCRIPTION
osg on ubuntu20.04 seems to fail to set an automatic default camera position properly.

This sets a default position as seen in the image below (roughly what is set automatically in previous osg versions)

![Bildschirmfoto von 2022-01-28 14-28-19](https://user-images.githubusercontent.com/7943934/151555149-2b35f7ac-22d8-4cc1-b628-0100156c49fe.png)

