### PR TITLE
Remove remaining dependencies to qt4

### DIFF
--- a/src/vizkit3d.pc.in
+++ b/src/vizkit3d.pc.in
@@ -6,6 +6,6 @@ includedir=${prefix}/include
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
-Requires: QtCore QtGui openscenegraph openscenegraph-osgManipulator openscenegraph-osgViewer @DEPS_PKGCONFIG@
+Requires: Qt5Core Qt5Gui openscenegraph openscenegraph-osgManipulator openscenegraph-osgViewer @DEPS_PKGCONFIG@
 Libs: -L${libdir} -l@PROJECT_NAME@
 Cflags: -I${includedir}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-rock_find_qt4()
+rock_find_qt5()
 
 rock_testsuite(testGUI suite.cpp testWidget.cpp
     DEPS vizkit3d


### PR DESCRIPTION
The pkg-config dependencies to `QtCore` and `QtGui` point to the Qt4 versions. These need to be called `Qt5Core` and `Qt5Gui`.