### PR TITLE
Need to remove the prefixes

### DIFF
--- a/src/QPropertyBrowserWidget.hpp
+++ b/src/QPropertyBrowserWidget.hpp
@@ -1,9 +1,9 @@
 #ifndef QPROPERTYBROWSERWIDGET_HPP
 #define QPROPERTYBROWSERWIDGET_HPP
 
-#include <QtPropertyBrowser/qttreepropertybrowser.h>
-#include <QtPropertyBrowser/qtvariantproperty.h>
-#include <QtPropertyBrowser/qtpropertymanager.h>
+#include <qttreepropertybrowser.h>
+#include <qtvariantproperty.h>
+#include <qtpropertymanager.h>
 
 #include <QWidget>
 #include <QHash>

--- a/src/vizkit3d.pc.in
+++ b/src/vizkit3d.pc.in
@@ -6,6 +6,6 @@ includedir=${prefix}/include
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
-Requires: Qt5Core Qt5Gui openscenegraph openscenegraph-osgManipulator openscenegraph-osgViewer @DEPS_PKGCONFIG@
+Requires: Qt5Core Qt5Gui Qt5Widgets openscenegraph openscenegraph-osgManipulator openscenegraph-osgViewer @DEPS_PKGCONFIG@
 Libs: -L${libdir} -l@PROJECT_NAME@
 Cflags: -I${includedir}


### PR DESCRIPTION
 since QtPropertyBrowser already has it as part of the exported include path