### PR TITLE
Revert "openscenegraph-osgQt renamed to openscenegraph-osgQt5"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,7 +44,7 @@ rock_library(vizkit3d
 	Boost::thread
     DEPS_PKGCONFIG
     	osgViz
-	openscenegraph-osgQt5
+	osgQt
 	ManipulationClickHandler
 )
 


### PR DESCRIPTION
This reverts commit 6af04013cc431924240f4b4334a33f83cddce731. This was accidentally left in the pull request.