### PR TITLE
Make Qts moc look at the headers needing MOCing

### DIFF
--- a/viz/CMakeLists.txt
+++ b/viz/CMakeLists.txt
@@ -1,13 +1,16 @@
+
+rock_find_qt5(Core)
 rock_vizkit_plugin(vizkit3d-viz
     SOURCES
     	PluginLoader.cpp
     	GridVisualization.cpp
 	TextureBoxVisualization.cpp
 	ModelVisualization.cpp
-    HEADERS 
-    	GridVisualization.hpp 
-    	TextureBoxVisualization.hpp 
-    	ModelVisualization.hpp
+    MOC
+	GridVisualization.hpp
+	TextureBoxVisualization.hpp
+	ModelVisualization.hpp
+	PluginLoader.hpp
     DEPS 
     	vizkit3d
 )


### PR DESCRIPTION
Also makes the plugin information visible to rock-display. One (set of) plugin(s) down, 11 more to go.