### PR TITLE
Feature/qt5

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,17 @@ rock_find_qt5(Core OpenGL Widgets UiPlugin REQUIRED)
 find_package(QtPropertyBrowser REQUIRED)
 find_package(Boost COMPONENTS Thread System REQUIRED)
 
+pkg_check_modules(OSGQT QUIET osgQt)
+pkg_check_modules(OPENSCENEGRAPH_OSGQT5 QUIET openscenegraph-osgQt5)
+
+if(${OPENSCENEGRAPH_OSGQT5_FOUND})
+  set(OSGQT_PKGCONFIG_NAME "openscenegraph-osgQt5")
+elseif(${OSGQT_FOUND})
+  set(OSGQT_PKGCONFIG_NAME "osgQt")
+else()
+  message(SEND_ERROR "Could not find osgQt or openscenegraph-osgQt5 with pkg-config")
+endif()
+
 rock_library(vizkit3d
 	SOURCES
 		QtThreadedWidget.cpp
@@ -44,7 +55,7 @@ rock_library(vizkit3d
 		Boost::thread
 	DEPS_PKGCONFIG
 		osgViz
-		osgQt
+		${OSGQT_PKGCONFIG_NAME}
 		ManipulationClickHandler
 )
 

--- a/viz/CMakeLists.txt
+++ b/viz/CMakeLists.txt
@@ -6,6 +6,10 @@ rock_vizkit_plugin(vizkit3d-viz
     	GridVisualization.cpp
 	TextureBoxVisualization.cpp
 	ModelVisualization.cpp
+    HEADERS
+	GridVisualization.hpp
+	TextureBoxVisualization.hpp
+	ModelVisualization.hpp
     MOC
 	GridVisualization.hpp
 	TextureBoxVisualization.hpp


### PR DESCRIPTION
Some more fixes/changes for qt5 support, adds back installing of headers that has been removed in error and allows to find gentoos version of osgQt. There is some issue under ubuntu 18.04 where it fails to find boost components. Not sure what the correct incantations could be for that, it seems to work for other packages.