### PR TITLE
Feature/qt5: osg_qt5 is a dependency, fix HEADERS install

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -10,6 +10,7 @@
     <depend package="osg" />
     <depend package="qt5" />
     <depend package="qt5-opengl" />
+    <depend package="osg_qt5" />
     <depend package="boost" />
     <depend package="base/cmake" />
     <depend package="gui/osgviz" />

--- a/viz/CMakeLists.txt
+++ b/viz/CMakeLists.txt
@@ -6,6 +6,10 @@ rock_vizkit_plugin(vizkit3d-viz
     	GridVisualization.cpp
 	TextureBoxVisualization.cpp
 	ModelVisualization.cpp
+    HEADERS
+	GridVisualization.hpp
+	TextureBoxVisualization.hpp
+	ModelVisualization.hpp
     MOC
 	GridVisualization.hpp
 	TextureBoxVisualization.hpp


### PR DESCRIPTION
Fixes a misunderstanding of the rock macros and adds osg_qt5 as dependency, which is and should not be injected by the rock-core/package_set. @planthaber , please have a look and merge if acceptable.