### PR TITLE
Make this package depend on osg_qt4

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -10,6 +10,7 @@
     <depend package="osg" />
     <depend package="qt4" />
     <depend package="qt4-opengl" />
+    <depend package="osg_qt4" />
     <depend package="boost" />
     <depend package="base/cmake" />
     <depend package="gui/osgviz" />


### PR DESCRIPTION
Adds osg_qt4 as dependency, which is and should not be injected by the rock-core/package_set. @planthaber , please have a look and merge if acceptable.