### PR TITLE
osg_qt5 => gui/osg_qt5

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -10,7 +10,7 @@
     <depend package="osg" />
     <depend package="qt5" />
     <depend package="qt5-opengl" />
-    <depend package="osg_qt5" />
+    <depend package="gui/osg_qt5" />
     <depend package="boost" />
     <depend package="base/cmake" />
     <depend package="gui/osgviz" />


### PR DESCRIPTION
@planthaber this is basically the same change as for osg_qt4, i have no idea how this worked earlier.