### PR TITLE
make the root of the transformer display selectable

### DIFF
--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -128,6 +128,10 @@ bool Vizkit3DConfig::isAxesLabels() const
     return getWidget()->isAxesLabels();
 }
 
+void Vizkit3DConfig::setTransformerRootFrame (const QStringList &frames) {
+    return getWidget()->setRootFrame(frames.front());
+}
+
 namespace
 {
     struct ManipulatorDefinition
@@ -926,6 +930,7 @@ void Vizkit3DWidget::setTransformation(const QString &source_frame,const QString
         registerClickHandler(target_frame.toStdString());
         
         emit propertyChanged("frame");
+        emit propertyChanged("transformerroot");
         // first: VizPluginBase*
         // second: osg::ref_ptr<osg::Group>
         

--- a/src/Vizkit3DWidget.hpp
+++ b/src/Vizkit3DWidget.hpp
@@ -152,6 +152,7 @@ namespace vizkit3d
             Q_PROPERTY( bool axes_labels READ isAxesLabels WRITE setAxesLabels)
             Q_PROPERTY( QColor background READ getBackgroundColor WRITE setBackgroundColor)
             Q_PROPERTY( QStringList frame READ getVisualizationFrames WRITE setVisualizationFrame)
+            Q_PROPERTY( QStringList transformerroot READ getVisualizationFrames WRITE setTransformerRootFrame)
             Q_PROPERTY( bool environment READ isEnvironmentPluginEnabled WRITE setEnvironmentPluginEnabled)
             Q_PROPERTY( bool transformer READ isTransformer WRITE setTransformer)
             Q_ENUMS( CAMERA_MANIPULATORS )
@@ -185,6 +186,8 @@ namespace vizkit3d
 
             QColor getBackgroundColor()const;
             void setBackgroundColor(QColor color);
+
+            void setTransformerRootFrame (const QStringList &frames);
 
             /** Converts a manipulator ID to its name */
             static QString manipulatorIDToName(CAMERA_MANIPULATORS id);


### PR DESCRIPTION
Sometimes devs might want to switch the visualization root to another frame, e.g. switch from odometry to slam this is now possible