### PR TITLE
Fix qt5 pc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,8 +47,16 @@ rock_library(vizkit3d
 		CoordinateFrame.hpp
 		EnvPluginBase.hpp
 		DefaultManipulator.hpp
-	LIBS
+	DEPS_TARGET
+# QtPropertyBrowser properly sets up its target, fails to setup the plain
+# cmake variables(thus cannot be used with DEPS_CMAKE) and does not have a
+# pkg-config file(cannot be used with DEPS_PKGCONFIG).
 		QtPropertyBrowser
+	LIBS
+# Qt has proper targets so potentially could be used with DEPS_TARGET, but
+# it also provides proper pkg-config files, that are prefered there. Here,
+# we have the qt dependencies hardcoded into the .pc.in and use the cmake
+# targets for the cmake side.
 		Qt5::Core
 		Qt5::Widgets
 		Qt5::OpenGL

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,7 +25,7 @@ rock_library(vizkit3d
 		CoordinateFrame.cpp
 		DefaultManipulator.cpp
 		EnableGLDebugOperation.cpp
-		Vizkit3DPlugin.cpp
+		Vizkit3DPlugin.cpp 
 		Vizkit3DWidget.cpp
 		QVizkitMainWindow.cpp
 		QPropertyBrowserWidget.cpp
@@ -47,7 +47,6 @@ rock_library(vizkit3d
 		CoordinateFrame.hpp
 		EnvPluginBase.hpp
 		DefaultManipulator.hpp
-
 	LIBS
 		QtPropertyBrowser
 		Qt5::Core
@@ -77,7 +76,7 @@ rock_library(vizkitmainwindowloader
         vizkit3d
     NOINSTALL # installs in a non-standard location
 )
-
+    
 install(TARGETS vizkitwidgetloader #vizkitmainwindowloader
     LIBRARY DESTINATION lib/qt/designer
     ARCHIVE DESTINATION lib/qt/designer)

--- a/src/QPropertyBrowserWidget.hpp
+++ b/src/QPropertyBrowserWidget.hpp
@@ -1,9 +1,9 @@
 #ifndef QPROPERTYBROWSERWIDGET_HPP
 #define QPROPERTYBROWSERWIDGET_HPP
 
-#include <QtPropertyBrowser/qttreepropertybrowser.h>
-#include <QtPropertyBrowser/qtvariantproperty.h>
-#include <QtPropertyBrowser/qtpropertymanager.h>
+#include <qttreepropertybrowser.h>
+#include <qtvariantproperty.h>
+#include <qtpropertymanager.h>
 
 #include <QWidget>
 #include <QHash>
@@ -13,21 +13,21 @@ namespace vizkit3d {
 class QPropertyBrowserWidget : public QtTreePropertyBrowser
 {
     Q_OBJECT
-
+    
 public:
     QPropertyBrowserWidget(QWidget* parent = 0);
     void addProperties(QObject* obj,QObject* parent = NULL);
     void removeProperties(QObject* obj);
     void addGlobalProperties(QObject* obj, const QStringList &property_list);
     void disableProperty(QObject* obj);
-    void enableProperty(QObject* obj);
-
+    void enableProperty(QObject* obj);    
+    
 protected slots:
     void propertyChangedInGUI(QtProperty *property, const QVariant &val);
     void propertyChangedInObject(QString property_name);
     void propertyChangedInObject();
     void propObjDestroyed(QObject*);
-
+    
 private:
     QHash<QtProperty*, QObject*> propertyToObject;
     QHash<QObject*, QHash<QString ,QtProperty*>* > objectToProperties;

--- a/src/vizkit3d.pc.in
+++ b/src/vizkit3d.pc.in
@@ -6,6 +6,6 @@ includedir=${prefix}/include
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
-Requires: Qt5Core Qt5Gui Qt5Widgets openscenegraph openscenegraph-osgManipulator openscenegraph-osgViewer @DEPS_PKGCONFIG@
-Libs: -L${libdir} -l@PROJECT_NAME@
-Cflags: -I${includedir}
+Requires: Qt5Core Qt5Gui Qt5Widgets openscenegraph openscenegraph-osgManipulator openscenegraph-osgViewer @PKGCONFIG_REQUIRES@
+Libs: -L${libdir} -l@PROJECT_NAME@ @PKGCONFIG_LIBS@
+Cflags: -I${includedir} @PKGCONFIG_CFLAGS@


### PR DESCRIPTION
This allows `Autoproj.config.separate_prefixes = true` builds to work again alongside correcting the pkgconfig .pc file to correctly include the QtPropertyBrowser library and include path.

@haider8645, please check if this works for you.