### PR TITLE
add helper function that allow plugins to update viz pose only on demand

### DIFF
--- a/src/Vizkit3DPlugin.cpp
+++ b/src/Vizkit3DPlugin.cpp
@@ -7,6 +7,8 @@
 
 #include "Vizkit3DPlugin.hpp"
 #include "Vizkit3DWidget.hpp"
+#include "TransformerGraph.hpp"
+
 
 namespace vizkit3d{
     class ClickHandler : public osgviz::Clickable
@@ -315,6 +317,7 @@ void VizPluginBase::setVisualizationFrameFromList(const QStringList &frames)
         return; 
     getWidget()->setPluginDataFrameIntern(frames.front(),this);
     current_frame = frames.front();
+    resetManualVizPose();
 }
 
 void VizPluginBase::setVisualizationFrame(const QString &frame)
@@ -324,6 +327,7 @@ void VizPluginBase::setVisualizationFrame(const QString &frame)
     getWidget()->setPluginDataFrameIntern(frame,this);
     current_frame = frame;
     emit propertyChanged("frame");
+    resetManualVizPose();
 }
 
 bool VizPluginBase::getEvaluatesClicks() const{
@@ -334,3 +338,31 @@ void VizPluginBase::setEvaluatesClicks (const bool &value){
     click_handler->enable(value);
 }
 
+void VizPluginBase::setManualVizPoseUpdateEnabled(const bool &newvalue) {
+    if (newvalue == true) {
+        manualVizFrame = getVisualizationFrame().toStdString();
+        setVisualizationFrame("world_osg");
+        updateManualVizPose();
+    } else {
+        setVisualizationFrame(QString(manualVizFrame.c_str()));
+        resetManualVizPose();
+    }
+}
+
+void VizPluginBase::updateManualVizPose() {
+    // save position of this update
+    osg::Vec3d translation;
+    osg::Quat orientation;
+
+    if (TransformerGraph::getTransformation(*(getWidget()->getRootNode()), "world_osg", manualVizFrame, orientation, translation)) {
+        rootNode->setPosition(translation);
+        rootNode->setAttitude(orientation);
+    } else {
+        printf("could not get transform world_osg to %s\n", manualVizFrame.c_str());
+    }
+}
+
+void VizPluginBase::resetManualVizPose() {
+    rootNode->setPosition(osg::Vec3d());
+    rootNode->setAttitude(osg::Quat());
+}

--- a/src/Vizkit3DPlugin.hpp
+++ b/src/Vizkit3DPlugin.hpp
@@ -306,6 +306,26 @@ class VizPluginBase : public QObject
         QString vizkit3d_plugin_name;
         VizPluginRubyAdapterCollection adapterCollection;
 
+        /** helper function to allow to keep visualization at the position where the data was updated
+         *  plugins using this, need to call updateVizPose() after their data was updated
+         *  the frame that is used to update the position when updateManualVizPose() will be the one that is set
+         *  when calling this function
+         */
+        void setManualVizPoseUpdateEnabled(const bool &newvalue);
+
+        /** use the transformer pose of the visualization frame that was set when setManualVizPoseUpdateEnabled(true) was called
+         * to update the position of the visualization, plugins that set setManualVizPoseUpdateEnabled(true) should
+         * call this function in their updateDataIntern() vinction
+         */
+        void updateManualVizPose();
+
+        void resetManualVizPose();
+
+	/** Returns an invalid QVariant 
+	 * used to invalidate properties
+	 */ 
+	QVariant _invalidate()const;
+
     private:
 	std::vector<std::function<void(float, float, float)>> pickCallbacks;
       
@@ -331,6 +351,8 @@ class VizPluginBase : public QObject
         std::shared_ptr<ClickHandler> click_handler;
         unsigned int max_old_data;
         QString current_frame;
+        std::string manualVizFrame;
+
 };
 
 template <typename T> class Vizkit3DPlugin;


### PR DESCRIPTION
Normally the viz pose is updated on every transformer update, this allows to set the viz pose manually when new data arrives. This way e.g. point clouds can stay to be visualized on the position where they were received rather than moving together with the frame.

The feature MUST be implemented by the plugin as the Widgett does not knoe when the updateData function is called