### PR TITLE
add LOD support to disable/change viz based on camera distance

### DIFF
--- a/src/Vizkit3DPlugin.cpp
+++ b/src/Vizkit3DPlugin.cpp
@@ -59,17 +59,19 @@ class VizPluginBase::CallbackAdapter : public osg::NodeCallback
 
 VizPluginBase::VizPluginBase(QObject *parent)
     : QObject(parent), oldNodes(NULL), isAttached(false), dirty( false ),  plugin_enabled(true),
-    keep_old_data(false),max_old_data(100)
+    keep_old_data(false),max_old_data(100),minrange(0),maxrange(1000)
 {
     rootNode = new osgviz::Object();
     click_handler = std::shared_ptr<ClickHandler>(new ClickHandler(*this));
     rootNode->addClickableCallback(click_handler);
     nodeCallback = new CallbackAdapter(this);
     rootNode->setUpdateCallback(nodeCallback);
+    lodNode = new osg::LOD();
+    rootNode->addChild(lodNode);
     vizNode = new osg::PositionAttitudeTransform();
-    rootNode->addChild(vizNode);
+    lodNode->addChild(vizNode, minrange, maxrange);
     oldNodes = new osg::Group();
-    rootNode->addChild(oldNodes);
+    lodNode->addChild(oldNodes, minrange, maxrange);
 }
 
 VizPluginBase::~VizPluginBase()
@@ -95,9 +97,42 @@ double VizPluginBase::getScale() const
     return (scale.x()+scale.y()+scale.y())/3;
 }
 
+
+double VizPluginBase::getMinVizRange() const
+{
+    return lodNode->getMinRange(0);
+}
+
+void VizPluginBase::setMinVizRange(double distance) {
+    minrange = distance;
+    // vizNode
+    lodNode->setRange(0, minrange, maxrange);
+    // oldNodes
+    lodNode->setRange(1, minrange, maxrange);
+}
+
+double VizPluginBase::getMaxVizRange() const
+{
+    return lodNode->getMaxRange(0);
+}
+
+void VizPluginBase::setMaxVizRange(double distance)
+{
+    maxrange = distance;
+    // vizNode
+    lodNode->setRange(0, minrange, maxrange);
+    // oldNodes
+    lodNode->setRange(1, minrange, maxrange);
+}
+
 osg::ref_ptr<osg::Group> VizPluginBase::getRootNode() const 
 {
     return rootNode;
+}
+
+osg::ref_ptr<osg::LOD> VizPluginBase::getLODNode() const
+{
+    return lodNode;
 }
 
 void VizPluginBase::click(float x,float y, int buttonMask, int modifierMask)

--- a/src/Vizkit3DPlugin.hpp
+++ b/src/Vizkit3DPlugin.hpp
@@ -6,6 +6,7 @@
 
 #include <osg/NodeCallback>
 #include <osg/Group>
+#include <osg/LOD>
 #include <osg/PositionAttitudeTransform>
 
 #include <boost/thread/mutex.hpp>
@@ -127,7 +128,8 @@ class VizPluginBase : public QObject
     Q_PROPERTY(int MaxOldData READ getMaxOldData WRITE setMaxOldData)
     Q_PROPERTY(QStringList frame READ getVisualizationFrames WRITE setVisualizationFrameFromList)
     Q_PROPERTY(double scale READ getScale WRITE setScale)
-
+    Q_PROPERTY(double minVizRange READ getMinVizRange WRITE setMinVizRange)
+    Q_PROPERTY(double maxVizRange READ getMaxVizRange WRITE setMaxVizRange)
 
     public:
         VizPluginBase(QObject *parent=NULL);
@@ -148,6 +150,7 @@ class VizPluginBase : public QObject
                 * plugin's nodes */
         osg::ref_ptr<osg::Group> getVizNode() const;
         osg::ref_ptr<osg::Group> getRootNode() const;
+        osg::ref_ptr<osg::LOD> getLODNode() const;
 
         /**
          * @return a vector of QDockWidgets provided by this class.
@@ -233,6 +236,26 @@ class VizPluginBase : public QObject
         */
         void setScale(double scale);
 
+       /**
+        * Returns the min display range of the plugin
+        */
+        double getMinVizRange() const;
+
+       /**
+        * Sets the min display range of the plugin
+        */
+        void setMinVizRange(double distance);
+
+       /**
+        * Returns the max display range of the plugin
+        */
+        double getMaxVizRange() const;
+
+       /**
+        * Sets the max display range of the plugin
+        */
+        void setMaxVizRange(double distance);
+
         /**
          * @return whether click events should be evaluated by this plugin or not
          */
@@ -315,6 +338,7 @@ class VizPluginBase : public QObject
 
         osg::ref_ptr<osg::Node> mainNode;               //node which is used by the child class
         osg::ref_ptr<osgviz::Object> rootNode;              //node which is the osg root node of the pluign 
+        osg::ref_ptr<osg::LOD> lodNode;              //node which allows visibility settings for distances from the camera 
         osg::ref_ptr<osg::PositionAttitudeTransform> vizNode; //node which describes the transformation between rootNode and mainNode
         osg::ref_ptr<osg::Group> oldNodes;              //node which is the root node for all old visualization graphs of the plugin  
 
@@ -331,6 +355,7 @@ class VizPluginBase : public QObject
         std::shared_ptr<ClickHandler> click_handler;
         unsigned int max_old_data;
         QString current_frame;
+        double minrange, maxrange;
 };
 
 template <typename T> class Vizkit3DPlugin;


### PR DESCRIPTION
Adds options to en-/disable the viz of the plugin content based on the distance to the camera.

With this it is possible to remove a plugin content completely when the camera is too far/close. 

This also allows plugins to show a less detailed version version when the distance to the camera is high, thus lowering performance requirements.

