### PR TITLE
Update CMakeLists.txt cmake minimum and add project()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,11 @@
 # CMakeLists.txt has to be located in the project folder and cmake has to be
 # executed from 'project/build' with 'cmake ../'.
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
+project(vizkit3d
+	VERSION 0.2
+	DESCRIPTION "vizkit3d visualization library")
 find_package(Rock)
-rock_init(vizkit3d 1.0)
+rock_init()
 
 rock_find_cmake(Boost REQUIRED COMPONENTS thread system)
 rock_standard_layout()


### PR DESCRIPTION
cmake 3.5 is available with ubuntu 16.04. This breaks building on earlier ubuntus that are out of support for more than 4 years.

I am going to merge this in about a week.