### PR TITLE
Use Qt5 so change MOC to MOC5

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,7 +47,7 @@ rock_library(vizkit3d
 		CoordinateFrame.hpp
 		EnvPluginBase.hpp
 		DefaultManipulator.hpp
-	MOC
+	MOC5
 		QPropertyBrowserWidget.hpp
 		Vizkit3DPlugin.hpp
 		Vizkit3DWidget.hpp
@@ -79,7 +79,7 @@ rock_library(vizkitwidgetloader
     	QVizkitWidgetLoader.cpp
     DEPS
     	vizkit3d
-    MOC
+    MOC5
         QVizkitWidgetLoader.hpp
     NOINSTALL # installs in a non-standard location
 )
@@ -89,7 +89,7 @@ rock_library(vizkitmainwindowloader
         QVizkitMainWindowLoader.cpp
     DEPS
         vizkit3d
-    MOC
+    MOC5
         QVizkitMainWindowLoader.hpp
     NOINSTALL # installs in a non-standard location
 )


### PR DESCRIPTION
@pierrewillenbrockdfki although you implemented some fallback mechanism, it did not work with base/types feature/qt5
Only a consistent use of MOC5 seems to work