### PR TITLE
Add optional override of plugin default settings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,7 @@ set(VIZKIT3D_HEADERS
         QtThreadedWidget.hpp
         Vizkit3DBase.hpp
         Vizkit3DPlugin.hpp
+        Vizkit3DPluginDefaultSettings.hpp
         Vizkit3DWidget.hpp
         QVizkitMainWindow.hpp
         ColorConversionHelper.hpp

--- a/src/Vizkit3DPluginDefaultSettings.hpp
+++ b/src/Vizkit3DPluginDefaultSettings.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "Vizkit3DPlugin.hpp"
+//#include <QMetaObject>
+#include <QMetaMethod>
+
+namespace vizkit3d
+{
+
+/**
+ * @brief allows to set different default settings for plugins than 
+ * 
+ */
+class Vizkit3DPluginDefaultSettingsBase{
+ public:
+
+    virtual ~Vizkit3DPluginDefaultSettingsBase(){};
+    virtual bool apply(VizPluginBase *plugin) = 0;
+
+};
+
+
+
+template <class PLUGIN> class Vizkit3DPluginDefaultSettings : public Vizkit3DPluginDefaultSettingsBase {
+ public:
+
+    /**
+     * @brief add a confiugation to be added afer laoding the plugin settings->addConfig("setPointSize", Q_ARG(double, pointSize));
+     * 
+     * @param paramname name of the plugin function to invoke (e.g. "setPointSize")
+     * @param param a paramater defien by the Q_ARG macro (e.g. Q_ARG(double, pointSize))
+     */
+    void addConfig(const std::string& paramname, const QGenericArgument &param) {
+        params[paramname] = param;
+    }
+
+    bool apply(VizPluginBase *plugin) override {
+        PLUGIN* viz = dynamic_cast<PLUGIN*>(plugin);
+        if (viz) {
+            for (auto& param : params) {
+                QMetaObject::invokeMethod(viz, param.first.c_str(), Qt::DirectConnection, param.second);
+            }
+            return true;
+        }
+        return false;
+    }
+
+ private:
+    std::map<std::string, QGenericArgument> params;
+};
+
+}

--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -821,6 +821,10 @@ void Vizkit3DWidget::addPluginIntern(QObject* plugin,QObject *parent)
         viz_plugin->setParent(this);
         viz_plugin->setVisualizationFrame(getRootNode()->getName().c_str());
 
+        for (auto& defaultsettings : pluginDefaultSettingOverrides) {
+            defaultsettings->apply(viz_plugin);
+        }
+
         registerDataHandler(viz_plugin);
         setPluginEnabled(viz_plugin, viz_plugin->isPluginEnabled());
         addProperties(viz_plugin,parent);
@@ -1318,6 +1322,14 @@ void Vizkit3DWidget::setCameraManipulator(osg::ref_ptr<osgGA::CameraManipulator>
 
 osg::Camera* Vizkit3DWidget::getCamera() {
     return view->getCamera();
+}
+
+void Vizkit3DWidget::addPluginDefaultConfigOverrides(std::shared_ptr<Vizkit3DPluginDefaultSettingsBase> overrides) {
+    pluginDefaultSettingOverrides.push_back(overrides);
+}
+
+void Vizkit3DWidget::removePluginDefaultConfigOverrides() {
+    pluginDefaultSettingOverrides.clear();
 }
 
 void Vizkit3DWidget::setCameraManipulator(QString manipulator, bool resetToDefaultHome)

--- a/src/Vizkit3DWidget.hpp
+++ b/src/Vizkit3DWidget.hpp
@@ -2,6 +2,7 @@
 #define __VIZKIT_QVIZKITWIDGET__
 
 #include "Vizkit3DPlugin.hpp"
+#include "Vizkit3DPluginDefaultSettings.hpp"
 
 #if QT_VERSION < 0x050000
 #include <QtDesigner/QDesignerExportWidget>
@@ -259,6 +260,18 @@ namespace vizkit3d
              * @return osg::Camera* 
              */
             osg::Camera* getCamera();
+
+            /**
+             * @brief add default overrides to a Vizkit3DPlugin which are applied on loading the plugin, in case other defaults are needed than 
+             * the plugins implementation defaults
+             * 
+             * @param overrides your application can set up a shared_ptr>vizkit3d::Vizkit3DPluginDefaultSettings<Your Plugin>>
+             * and use the addConfig function of that class to let the settings be invoked after loading the plugin here
+             *  
+             */
+            void addPluginDefaultConfigOverrides(const std::shared_ptr<Vizkit3DPluginDefaultSettingsBase> overrides);
+
+            void removePluginDefaultConfigOverrides();
 
         public slots:
             void update();
@@ -576,6 +589,8 @@ namespace vizkit3d
 
             QPropertyBrowserWidget* propertyBrowserWidget;
             QDockWidget* propertyDocker;
+
+            std::vector<std::shared_ptr<Vizkit3DPluginDefaultSettingsBase>> pluginDefaultSettingOverrides;
 
     };
 }


### PR DESCRIPTION
Plugin type independent implementation to set other default options in vizkit3d plugins after loading the plugin.

The user application has to include the plugin header, create a Vizkit3DPluginDefaultSettings<Plugintype> object and add it to the widget using addPluginDefaultConfigOverrides()

The created Vizkit3DPluginDefaultSettings has an apply function that checks if the loaded plugin is the same type as the settings are created with and invokes function using QtMetoObject::Invoke() to call the functions, this way vitkid3d does not need to include headers of the plugind but is still able to do the settings afer laoding the plugin.

```cpp
    std::shared_ptr<vizkit3d::Vizkit3DPluginDefaultSettings<vizkit3d::PCLPointCloudVisualization>> pclsettings = std::make_shared<vizkit3d::Vizkit3DPluginDefaultSettings<vizkit3d::PCLPointCloudVisualization>>();
    pclsettings->addConfig("setPointSize", Q_ARG(double, pointSize));
    vizkit3dwidget->addPluginDefaultConfigOverrides(pclsettings);
```