### PR TITLE
Little bits missed during the qt5 support integration from fixing calling osgviz frame() on hidden windows.

### DIFF
--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -449,13 +449,13 @@ void Vizkit3DWidget::update()
 {
     QWidget::update();
 
-#if QT_VERSION >= 0x050000
     if(isVisible()) {
+#if QT_VERSION >= 0x050000
         window->frame();
-    }
 #else
-    osgviz->update(); // osg update called trough window->frame();
+        osgviz->update(); // osg update called trough window->frame();
 #endif
+    }
 
 }
 

--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -226,8 +226,8 @@ void Vizkit3DConfig::setCameraManipulator(QStringList const& manipulator)
 Vizkit3DWidget::Vizkit3DWidget(QWidget* parent,const QString &world_name,bool auto_update)
     : QMainWindow(parent)
     , env_plugin(NULL), clickHandler(new osgviz::ManipulationClickHandler),
-    movedHandler(*this), movingHandler(*this), selectedHandler(*this)
-    , timerRunning(auto_update)
+      movedHandler(*this), movingHandler(*this), selectedHandler(*this),
+      timerRunning(auto_update)
 {
     setEnabledManipulators(false);
     clickHandler->objectMoved.connect(movedHandler);


### PR DESCRIPTION
This was originally proposed in https://github.com/rock-core/gui-vizkit3d/issues/48 and then merged through the qt5 support work. The original branch is gone now, but these two changes have been omitted from that set.

This should restore functionality of the auto_update flag and prevent the qt4 side from calling osgviz->update() on hidden windows.